### PR TITLE
Make Wrapper Methods Public and Add Base URL

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -64,6 +64,26 @@ class TestWrappers(unittest.TestCase):
             }
         ])
     
+    def test_base_url(self):
+        z = zarr.open('data/test.ome.zarr')
+        w = ZarrDirectoryStoreWrapper(z, base_url="https://example.com")
+
+        raster_json = w._create_raster_json(
+            "https://example.com/raster_img"
+        )
+        
+        # TODO
+        # self.assertEqual(raster_json, {})
+
+        obj_file_defs, obj_routes = w.get_raster(8000, 'A', 0)
+        self.assertEqual(obj_file_defs, [
+            {
+                'fileType': 'raster.json',
+                'type': 'raster',
+                'url': 'https://example.com/A/0/raster'
+            }
+        ])
+    
     def test_anndata(self):
         adata = read_h5ad('data/habib17.processed.h5ad')
         w = AnnDataWrapper(adata)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -15,7 +15,7 @@ class TestWrappers(unittest.TestCase):
     def test_ome_tiff(self):
         w = OmeTiffWrapper("data/test.ome.tif", offsets_path="data/offsets.json", name="Test")
 
-        raster_json = w._create_raster_json(
+        raster_json = w.create_raster_json(
             "http://localhost:8000/raster_img",
             "http://localhost:8000/raster_offsets/offsets.json"
         )
@@ -48,7 +48,7 @@ class TestWrappers(unittest.TestCase):
         z = zarr.open('data/test.ome.zarr')
         w = ZarrDirectoryStoreWrapper(z)
 
-        raster_json = w._create_raster_json(
+        raster_json = w.create_raster_json(
             "http://localhost:8000/raster_img"
         )
         
@@ -68,7 +68,7 @@ class TestWrappers(unittest.TestCase):
         z = zarr.open('data/test.ome.zarr')
         w = ZarrDirectoryStoreWrapper(z, base_url="https://example.com")
 
-        raster_json = w._create_raster_json(
+        raster_json = w.create_raster_json(
             "https://example.com/raster_img"
         )
         
@@ -88,8 +88,8 @@ class TestWrappers(unittest.TestCase):
         adata = read_h5ad('data/habib17.processed.h5ad')
         w = AnnDataWrapper(adata)
 
-        cells_json = w._create_cells_json()
-        cell_sets_json = w._create_cell_sets_json()
+        cells_json = w.create_cells_json()
+        cell_sets_json = w.create_cell_sets_json()
 
         obj_file_defs, obj_routes = w.get_cells(8000, 'A', 0)
         self.assertEqual(obj_file_defs, [{'type': 'cells', 'fileType': 'cells.json', 'url': 'http://localhost:8000/A/0/cells'}])

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -9,6 +9,9 @@ from .constants import DataType as dt, FileType as ft
 from .entities import Cells, CellSets
 
 class AbstractWrapper:
+
+    _base_url = ""
+
     """
     An abstract class that can be extended when
     implementing custom dataset object wrapper classes. 
@@ -124,6 +127,9 @@ class AbstractWrapper:
             return self.get_expression_matrix(port, dataset_uid, obj_i)
 
     def _get_url(self, port, dataset_uid, obj_i, suffix):
+        # A base URL is defined for this so this is used outside of Jupyter notebook.
+        if self._base_url:
+            return f"{self._base_url}/{dataset_uid}/{obj_i}/{suffix}"
         return f"http://localhost:{port}/{dataset_uid}/{obj_i}/{suffix}"
 
     def _get_route(self, dataset_uid, obj_i, suffix):
@@ -132,10 +138,11 @@ class AbstractWrapper:
 
 class OmeTiffWrapper(AbstractWrapper):
 
-    def __init__(self, img_path, offsets_path=None, name=""):
+    def __init__(self, img_path, offsets_path=None, name="", base_url=""):
         self.img_path = img_path
         self.offsets_path = offsets_path
         self.name = name
+        self._base_url = base_url
 
     def _create_raster_json(self, img_url, offsets_url):
         raster_json = {
@@ -192,7 +199,8 @@ class OmeTiffWrapper(AbstractWrapper):
 
 class ZarrDirectoryStoreWrapper(AbstractWrapper):
 
-    def __init__(self, z, name=""):
+    def __init__(self, z, name="", base_url=""):
+        self._base_url = base_url
         self.z = z
         self.name = name
 
@@ -273,10 +281,10 @@ class ZarrDirectoryStoreWrapper(AbstractWrapper):
 
 
 class AnnDataWrapper(AbstractWrapper):
-    def __init__(self, adata, use_highly_variable_genes=True):
+    def __init__(self, adata, use_highly_variable_genes=True, base_url=""):
         self.adata = adata
         self.tempdir = tempfile.mkdtemp()
-
+        self._base_url = base_url
         self.use_highly_variable_genes = use_highly_variable_genes
 
     def _create_cells_json(self):
@@ -438,8 +446,9 @@ class AnnDataWrapper(AbstractWrapper):
 
 class LoomWrapper(AbstractWrapper):
 
-    def __init__(self, loom):
+    def __init__(self, loom, base_url=""):
         self.loom = loom
+        self._base_url = base_url
 
     def get_cells(self, port, dataset_uid, obj_i):
         obj_routes = []

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -144,7 +144,7 @@ class OmeTiffWrapper(AbstractWrapper):
         self.name = name
         self._base_url = base_url
 
-    def _create_raster_json(self, img_url, offsets_url):
+    def create_raster_json(self, img_url, offsets_url):
         raster_json = {
             "schemaVersion": "0.0.2",
             "images": [
@@ -172,7 +172,7 @@ class OmeTiffWrapper(AbstractWrapper):
         img_dir_path, img_url = self.img_path, self._get_url(port, dataset_uid, obj_i, "raster_img")
         offsets_dir_path, offsets_url = (None, None) if self.offsets_path is None else (self._get_offsets_dir(), self._get_url(port, dataset_uid, obj_i, os.path.join("raster_offsets", self._get_offsets_filename())))
 
-        raster_json = self._create_raster_json(img_url, offsets_url)
+        raster_json = self.create_raster_json(img_url, offsets_url)
 
         obj_routes = [
             Mount(self._get_route(dataset_uid, obj_i, "raster_img"),
@@ -204,7 +204,7 @@ class ZarrDirectoryStoreWrapper(AbstractWrapper):
         self.z = z
         self.name = name
 
-    def _create_raster_json(self, img_url):
+    def create_raster_json(self, img_url):
         raster_json = {
             "schemaVersion": "0.0.2",
             "images": [
@@ -257,7 +257,7 @@ class ZarrDirectoryStoreWrapper(AbstractWrapper):
             if type(self.z) == zarr.hierarchy.Group:
                 img_dir_path = self.z.store.path
 
-                raster_json = self._create_raster_json(
+                raster_json = self.create_raster_json(
                     self._get_url(port, dataset_uid, obj_i, "raster_img"),
                 )
 
@@ -287,7 +287,7 @@ class AnnDataWrapper(AbstractWrapper):
         self._base_url = base_url
         self.use_highly_variable_genes = use_highly_variable_genes
 
-    def _create_cells_json(self):
+    def create_cells_json(self):
         adata = self.adata
         available_embeddings = list(adata.obsm.keys())
 
@@ -298,7 +298,7 @@ class AnnDataWrapper(AbstractWrapper):
             cells.add_mapping(e, mapping)
         return cells.json
 
-    def _create_cell_sets_json(self):
+    def create_cell_sets_json(self):
         adata = self.adata
         cell_sets = CellSets(first_node_name = 'Clusters')
 
@@ -318,7 +318,7 @@ class AnnDataWrapper(AbstractWrapper):
 
         return cell_sets.json
     
-    def _create_exp_matrix_zarr(self):
+    def create_exp_matrix_zarr(self):
         
         try:
             import zarr
@@ -378,7 +378,7 @@ class AnnDataWrapper(AbstractWrapper):
         try:
             import anndata
             if type(self.adata) == anndata.AnnData:
-                cells_json = self._create_cells_json()
+                cells_json = self.create_cells_json()
 
                 obj_routes = [
                     Route(self._get_route(dataset_uid, obj_i, "cells"),
@@ -402,7 +402,7 @@ class AnnDataWrapper(AbstractWrapper):
         try:
             import anndata
             if type(self.adata) == anndata.AnnData:
-                cell_sets_json = self._create_cell_sets_json()
+                cell_sets_json = self.create_cell_sets_json()
 
                 obj_routes = [
                     Route(self._get_route(dataset_uid, obj_i, "cell-sets"),
@@ -424,7 +424,7 @@ class AnnDataWrapper(AbstractWrapper):
         obj_routes = []
         obj_file_defs = []
 
-        zarr_tempdir, zarr_filepath = self._create_exp_matrix_zarr()
+        zarr_tempdir, zarr_filepath = self.create_exp_matrix_zarr()
 
         if zarr_tempdir is not None:
             obj_routes = [

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -318,7 +318,7 @@ class AnnDataWrapper(AbstractWrapper):
 
         return cell_sets.json
     
-    def create_exp_matrix_zarr(self):
+    def create_exp_matrix_zarr(self, filepath=""):
         
         try:
             import zarr
@@ -348,9 +348,11 @@ class AnnDataWrapper(AbstractWrapper):
             gexp_arr_ratio = 255 / gexp_arr_range
 
             gexp_norm_arr = (gexp_arr - gexp_arr_min) * gexp_arr_ratio
-
-            zarr_tempdir = self.tempdir
-            zarr_filepath = os.path.join(zarr_tempdir, 'matrix.zarr')
+            if filepath:
+                zarr_filepath = os.path.join(filepath, 'matrix.zarr')
+            else:
+                zarr_tempdir = self.tempdir
+                zarr_filepath = os.path.join(zarr_tempdir, 'matrix.zarr')
         
             z = zarr.open(
                 zarr_filepath,


### PR DESCRIPTION
This PR makes some formerly private methods publicand allows for a base url for configs and base filepath for zarr expression matrix.  This will allow us to build view configs more easily in HuBMAP as well as convert data using a "public api."  For example, for gene expression processing `create_exp_matrix_zarr` is likely needed to output the data since it will not be a straight usage of AnnData even once we have the loaders for `AnnData` completed.