### PR TITLE
Manage base_url in the abstract class

### DIFF
--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -10,7 +10,8 @@ from .entities import Cells, CellSets
 
 class AbstractWrapper:
 
-    _base_url = ""
+    def __init__(self, **kwargs):
+        self._base_url = kwargs['base_url'] if 'base_url' in kwargs else None
 
     """
     An abstract class that can be extended when
@@ -128,7 +129,7 @@ class AbstractWrapper:
 
     def _get_url(self, port, dataset_uid, obj_i, suffix):
         # A base URL is defined for this so this is used outside of Jupyter notebook.
-        if self._base_url:
+        if self._base_url is not None:
             return f"{self._base_url}/{dataset_uid}/{obj_i}/{suffix}"
         return f"http://localhost:{port}/{dataset_uid}/{obj_i}/{suffix}"
 
@@ -138,11 +139,11 @@ class AbstractWrapper:
 
 class OmeTiffWrapper(AbstractWrapper):
 
-    def __init__(self, img_path, offsets_path=None, name="", base_url=""):
+    def __init__(self, img_path, offsets_path=None, name="", **kwargs):
+        super().__init__(**kwargs)
         self.img_path = img_path
         self.offsets_path = offsets_path
         self.name = name
-        self._base_url = base_url
 
     def create_raster_json(self, img_url, offsets_url):
         raster_json = {
@@ -199,8 +200,8 @@ class OmeTiffWrapper(AbstractWrapper):
 
 class ZarrDirectoryStoreWrapper(AbstractWrapper):
 
-    def __init__(self, z, name="", base_url=""):
-        self._base_url = base_url
+    def __init__(self, z, name="", **kwargs):
+        super().__init__(**kwargs)
         self.z = z
         self.name = name
 
@@ -281,10 +282,10 @@ class ZarrDirectoryStoreWrapper(AbstractWrapper):
 
 
 class AnnDataWrapper(AbstractWrapper):
-    def __init__(self, adata, use_highly_variable_genes=True, base_url=""):
+    def __init__(self, adata, use_highly_variable_genes=True, **kwargs):
+        super().__init__(**kwargs)
         self.adata = adata
         self.tempdir = tempfile.mkdtemp()
-        self._base_url = base_url
         self.use_highly_variable_genes = use_highly_variable_genes
 
     def create_cells_json(self):
@@ -448,9 +449,9 @@ class AnnDataWrapper(AbstractWrapper):
 
 class LoomWrapper(AbstractWrapper):
 
-    def __init__(self, loom, base_url=""):
+    def __init__(self, loom, **kwargs):
+        super().__init__(**kwargs)
         self.loom = loom
-        self._base_url = base_url
 
     def get_cells(self, port, dataset_uid, obj_i):
         obj_routes = []

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -9,14 +9,19 @@ from .constants import DataType as dt, FileType as ft
 from .entities import Cells, CellSets
 
 class AbstractWrapper:
-
-    def __init__(self, **kwargs):
-        self._base_url = kwargs['base_url'] if 'base_url' in kwargs else None
-
     """
     An abstract class that can be extended when
     implementing custom dataset object wrapper classes. 
     """
+
+    def __init__(self, **kwargs):
+        """
+        Abstract constructor to be inherited by dataset wrapper classes.
+
+        :param str base_url: An optional base URL to use in dataset file definitions.
+        """
+        self._base_url = kwargs['base_url'] if 'base_url' in kwargs else None
+
     def get_cells(self, port, dataset_uid, obj_i):
         """
         Get the file definitions and server routes


### PR DESCRIPTION
I think we should manage the _base_url in the abstract class rather than adding it to each child class individually