### PR TITLE
Zarr for AnnData 

### DIFF
--- a/docs/notebooks/widget_brain.ipynb
+++ b/docs/notebooks/widget_brain.ipynb
@@ -89,7 +89,7 @@
    "source": [
     "## 3.1. Optionally, preprocess the dataset\n",
     "\n",
-    "This dataset contains 25,587 genes. Here, we select the top 50 highly variable genes for visualization."
+    "This dataset contains 25,587 genes, but has the `highly_variable` ones marked. We put those in a `obsm` entry for visualization (you may try to visualize all of the genes using `X` without a `genes_vars_filter` instead of `obsm/X_hvg` below, although both load time and interactions will be quite a bit slower)."
    ]
   },
   {
@@ -98,7 +98,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.pp.highly_variable_genes(adata, n_top_genes=50)"
+    "adata.obsm['X_hvg'] = adata[:, adata.var['highly_variable']].X.copy()"
    ]
   },
   {
@@ -147,7 +147,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = vc.add_dataset(name='Brain').add_object(AnnDataWrapper(adata, cell_set_obs_cols=[\"CellType\"]))"
+    "dataset = vc.add_dataset(name='Brain').add_object(AnnDataWrapper(\n",
+    "        adata,\n",
+    "        mappings_obsm=[\"X_umap\"],\n",
+    "        mappings_obsm_names=[\"UMAP\"],\n",
+    "        cell_set_obs=[\"CellType\"],\n",
+    "        cell_set_obs_names=[\"Cell Type\"],\n",
+    "        expression_matrix=\"X_hvg\",\n",
+    "        genes_var_filter=\"highly_variable\"\n",
+    "    )\n",
+    ")"
    ]
   },
   {
@@ -169,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scatterplot = vc.add_view(dataset, cm.SCATTERPLOT, mapping=\"X_umap\")\n",
+    "scatterplot = vc.add_view(dataset, cm.SCATTERPLOT, mapping=\"UMAP\")\n",
     "cell_sets = vc.add_view(dataset, cm.CELL_SETS)\n",
     "genes = vc.add_view(dataset, cm.GENES)\n",
     "heatmap = vc.add_view(dataset, cm.HEATMAP)"
@@ -211,6 +220,13 @@
     "vw = vc.widget()\n",
     "vw"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/notebooks/widget_brain.ipynb
+++ b/docs/notebooks/widget_brain.ipynb
@@ -153,7 +153,7 @@
     "        mappings_obsm_names=[\"UMAP\"],\n",
     "        cell_set_obs=[\"CellType\"],\n",
     "        cell_set_obs_names=[\"Cell Type\"],\n",
-    "        expression_matrix=\"X_hvg\",\n",
+    "        expression_matrix=\"obsm/X_hvg\",\n",
     "        genes_var_filter=\"highly_variable\"\n",
     "    )\n",
     ")"
@@ -220,13 +220,6 @@
     "vw = vc.widget()\n",
     "vw"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/notebooks/widget_loom.ipynb
+++ b/docs/notebooks/widget_loom.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,17 +53,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "('data/osmFISH_SScortex_mouse_all_cells.loom',\n",
-       " <http.client.HTTPMessage at 0x1a28c6ee0>)"
+       " <http.client.HTTPMessage at 0x1a4719fa0>)"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,22 +101,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "... storing 'ClusterName' as categorical\n",
-      "... storing 'Region' as categorical\n",
-      "... storing 'Fluorophore' as categorical\n"
+     "data": {
+      "text/plain": [
+       "778"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "int(adata.obs.index.tolist()[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "invalid literal for int() with base 10: 'a'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-31-233884bacd4e>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'a'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m: invalid literal for int() with base 10: 'a'"
      ]
     }
    ],
    "source": [
+    "int('a')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "vc = VitessceConfig(name='Loom Example', description='osmFISH dataset of the mouse cortex including all cells')\n",
-    "w = AnnDataWrapper(adata, cell_set_obs=[\"ClusterName\"], spatial_centroid_obsm=\"spatial\", mappings_obsm=[\"tSNE\"])\n",
+    "w = AnnDataWrapper(adata, cell_set_obs=[\"ClusterName\"], cell_set_obs_names=[\"Clusters\"], spatial_centroid_obsm=\"spatial\", mappings_obsm=[\"tSNE\"])\n",
     "dataset = vc.add_dataset(name='SScortex').add_object(w)\n",
     "tsne = vc.add_view(dataset, cm.SCATTERPLOT, mapping=\"tSNE\")\n",
     "cell_sets = vc.add_view(dataset, cm.CELL_SETS)\n",
@@ -141,35 +172,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9c6fe190bde249d2aa11ce380675547e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VitessceWidget(config={'version': '1.0.0', 'name': 'Loom Example', 'description': 'osmFISH dataset of the mous…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "vw = vc.widget()\n",
     "vw"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/notebooks/widget_loom.ipynb
+++ b/docs/notebooks/widget_loom.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,9 +53,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('data/osmFISH_SScortex_mouse_all_cells.loom',\n",
+       " <http.client.HTTPMessage at 0x1a28c6ee0>)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "os.makedirs(\"data\", exist_ok=True)\n",
     "loom_filepath = join(\"data\", \"osmFISH_SScortex_mouse_all_cells.loom\")\n",
@@ -71,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,12 +101,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "... storing 'ClusterName' as categorical\n",
+      "... storing 'Region' as categorical\n",
+      "... storing 'Fluorophore' as categorical\n"
+     ]
+    }
+   ],
    "source": [
     "vc = VitessceConfig(name='Loom Example', description='osmFISH dataset of the mouse cortex including all cells')\n",
-    "w = AnnDataWrapper(adata, cell_set_obs_cols=[\"ClusterName\"], spatial_obsm_key=\"spatial\")\n",
+    "w = AnnDataWrapper(adata, cell_set_obs=[\"ClusterName\"], spatial_centroid_obsm=\"spatial\", mappings_obsm=[\"tSNE\"])\n",
     "dataset = vc.add_dataset(name='SScortex').add_object(w)\n",
     "tsne = vc.add_view(dataset, cm.SCATTERPLOT, mapping=\"tSNE\")\n",
     "cell_sets = vc.add_view(dataset, cm.CELL_SETS)\n",
@@ -119,9 +141,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9c6fe190bde249d2aa11ce380675547e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VitessceWidget(config={'version': '1.0.0', 'name': 'Loom Example', 'description': 'osmFISH dataset of the mous…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "vw = vc.widget()\n",
     "vw"

--- a/docs/notebooks/widget_loom.ipynb
+++ b/docs/notebooks/widget_loom.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,21 +53,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "('data/osmFISH_SScortex_mouse_all_cells.loom',\n",
-       " <http.client.HTTPMessage at 0x1a4719fa0>)"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "os.makedirs(\"data\", exist_ok=True)\n",
     "loom_filepath = join(\"data\", \"osmFISH_SScortex_mouse_all_cells.loom\")\n",
@@ -83,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,47 +85,6 @@
     "## 4. Configure Vitessce\n",
     "\n",
     "Create a Vitessce view config."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "778"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "int(adata.obs.index.tolist()[0])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "ValueError",
-     "evalue": "invalid literal for int() with base 10: 'a'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-31-233884bacd4e>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'a'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m: invalid literal for int() with base 10: 'a'"
-     ]
-    }
-   ],
-   "source": [
-    "int('a')"
    ]
   },
   {

--- a/docs/notebooks/widget_pbmc.ipynb
+++ b/docs/notebooks/widget_pbmc.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,20 +56,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "('data/pbmc3k_final.h5ad', <http.client.HTTPMessage at 0x1a75a43d0>)"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "os.makedirs(\"data\", exist_ok=True)\n",
     "adata_filepath = join(\"data\", \"pbmc3k_final.h5ad\")\n",
@@ -87,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,31 +124,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[2021-01-08 16:43:53 -0500] [98213] [INFO] Running on http://127.0.0.1:8004 (CTRL + C to quit)\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8a3fe7f3ff5948a7a05f8e8a0e54c1c7",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VitessceWidget(config={'version': '1.0.0', 'name': 'PBMC Reference', 'description': '', 'datasets': [{'uid': '…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "vw = vc.widget()\n",
     "vw"

--- a/docs/notebooks/widget_pbmc.ipynb
+++ b/docs/notebooks/widget_pbmc.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,9 +56,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('data/pbmc3k_final.h5ad', <http.client.HTTPMessage at 0x1a75a43d0>)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "os.makedirs(\"data\", exist_ok=True)\n",
     "adata_filepath = join(\"data\", \"pbmc3k_final.h5ad\")\n",
@@ -76,29 +87,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
     "adata = read_h5ad(adata_filepath)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.1. Optionally, preprocess the dataset\n",
-    "\n",
-    "Before visualization, you may want to filter the list of genes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sc.pp.highly_variable_genes(adata, n_top_genes=50)"
    ]
   },
   {
@@ -112,14 +105,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
     "vc = VitessceConfig(name='PBMC Reference')\n",
-    "dataset = vc.add_dataset(name='PBMC 3k').add_object(AnnDataWrapper(adata, cell_set_obs_cols=[\"leiden\"]))\n",
-    "umap = vc.add_view(dataset, cm.SCATTERPLOT, mapping=\"X_umap\")\n",
-    "pca = vc.add_view(dataset, cm.SCATTERPLOT, mapping=\"X_pca\")\n",
+    "dataset = vc.add_dataset(name='PBMC 3k').add_object(AnnDataWrapper(adata, cell_set_obs=[\"leiden\"], cell_set_obs_names=[\"Leiden\"], mappings_obsm=[\"X_umap\", \"X_pca\"], mappings_obsm_names=[\"UMAP\", \"PCA\"], expression_matrix=\"X\"))\n",
+    "umap = vc.add_view(dataset, cm.SCATTERPLOT, mapping=\"UMAP\")\n",
+    "pca = vc.add_view(dataset, cm.SCATTERPLOT, mapping=\"PCA\")\n",
     "cell_sets = vc.add_view(dataset, cm.CELL_SETS)\n",
     "genes = vc.add_view(dataset, cm.GENES)\n",
     "heatmap = vc.add_view(dataset, cm.HEATMAP)\n",
@@ -142,11 +135,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2021-01-08 16:43:53 -0500] [98213] [INFO] Running on http://127.0.0.1:8004 (CTRL + C to quit)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8a3fe7f3ff5948a7a05f8e8a0e54c1c7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VitessceWidget(config={'version': '1.0.0', 'name': 'PBMC Reference', 'description': '', 'datasets': [{'uid': '…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "vw = vc.widget(proxy=True)\n",
+    "vw = vc.widget()\n",
     "vw"
    ]
   }

--- a/docs/notebooks/widget_pbmc_remote.ipynb
+++ b/docs/notebooks/widget_pbmc_remote.ipynb
@@ -1,0 +1,137 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "# Vitessce Widget Tutorial"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visualization of 3k PBMC reference from Remote Zarr Store"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Import dependencies\n",
+    "\n",
+    "We need to import the classes and functions that we will be using from the corresponding packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from os.path import join\n",
+    "from urllib.request import urlretrieve\n",
+    "from anndata import read_h5ad\n",
+    "import scanpy as sc\n",
+    "\n",
+    "from vitessce import (\n",
+    "    VitessceConfig,\n",
+    "    Component as cm,\n",
+    "    CoordinationType as ct,\n",
+    "    AnnDataWrapper,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Set the URL for the Remote Dataset\n",
+    "\n",
+    "For this example, we already have uploaded the `pbmc3k` dataset as a zarr store from the [scanpy docs](https://scanpy.readthedocs.io/en/stable/api/scanpy.datasets.pbmc3k.html) to the cloud."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'https://storage.googleapis.com/vitessce-demo-data/anndata-test/pbmc3k_processed.zarr/'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Create a Vitessce view config\n",
+    "\n",
+    "Define the data and views you would like to include in the widget."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vc = VitessceConfig(name='PBMC Reference')\n",
+    "dataset = vc.add_dataset(name='PBMC 3k').add_object(AnnDataWrapper(adata_url=url, cell_set_obs=[\"louvain\"], cell_set_obs_names=[\"Louvain\"], mappings_obsm=[\"X_umap\", \"X_pca\"], mappings_obsm_names=[\"UMAP\", \"PCA\"], expression_matrix=\"X\"))\n",
+    "umap = vc.add_view(dataset, cm.SCATTERPLOT, mapping=\"UMAP\")\n",
+    "pca = vc.add_view(dataset, cm.SCATTERPLOT, mapping=\"PCA\")\n",
+    "cell_sets = vc.add_view(dataset, cm.CELL_SETS)\n",
+    "genes = vc.add_view(dataset, cm.GENES)\n",
+    "heatmap = vc.add_view(dataset, cm.HEATMAP)\n",
+    "vc.layout((umap / pca) | ((cell_sets | genes) / heatmap));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Create the Vitessce widget"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A widget can be created with the `.widget()` method on the config instance. Here, the `proxy=True` parameter allows this widget to be used in a cloud notebook environment, such as Binder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vw = vc.widget()\n",
+    "vw"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/notebooks/widget_shortcut.ipynb
+++ b/docs/notebooks/widget_shortcut.ipynb
@@ -94,7 +94,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.pp.highly_variable_genes(adata, n_top_genes=200)"
+    "adata.obsm['X_hvg'] = adata[:, adata.var['highly_variable']].X.copy()"
    ]
   },
   {
@@ -110,7 +110,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vw = VitessceConfig.from_object(AnnDataWrapper(adata, cell_set_obs_cols=[\"CellType\"])).widget(height=800)\n",
+    "vw = VitessceConfig.from_object(AnnDataWrapper(\n",
+    "        adata,\n",
+    "        mappings_obsm=[\"X_umap\"],\n",
+    "        mappings_obsm_names=[\"UMAP\"],\n",
+    "        cell_set_obs=[\"CellType\"],\n",
+    "        cell_set_obs_names=[\"Cell Type\"],\n",
+    "        expression_matrix=\"X_hvg\",\n",
+    "        genes_var_filter=\"highly_variable\"\n",
+    ")).widget(height=800)\n",
     "vw"
    ]
   }
@@ -131,7 +139,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/widget_shortcut.ipynb
+++ b/docs/notebooks/widget_shortcut.ipynb
@@ -113,7 +113,6 @@
     "vw = VitessceConfig.from_object(AnnDataWrapper(\n",
     "        adata,\n",
     "        mappings_obsm=[\"X_umap\"],\n",
-    "        mappings_obsm_names=[\"UMAP\"],\n",
     "        cell_set_obs=[\"CellType\"],\n",
     "        cell_set_obs_names=[\"Cell Type\"],\n",
     "        expression_matrix=\"obsm/X_hvg\",\n",

--- a/docs/notebooks/widget_shortcut.ipynb
+++ b/docs/notebooks/widget_shortcut.ipynb
@@ -116,7 +116,7 @@
     "        mappings_obsm_names=[\"UMAP\"],\n",
     "        cell_set_obs=[\"CellType\"],\n",
     "        cell_set_obs_names=[\"Cell Type\"],\n",
-    "        expression_matrix=\"X_hvg\",\n",
+    "        expression_matrix=\"obsm/X_hvg\",\n",
     "        genes_var_filter=\"highly_variable\"\n",
     ")).widget(height=800)\n",
     "vw"

--- a/docs/widget_examples.rst
+++ b/docs/widget_examples.rst
@@ -11,3 +11,4 @@ Widget examples
    notebooks/widget_loom
    notebooks/widget_shortcut
    notebooks/widget_from_dict
+   notebooks/widget_pbmc_remote.ipynb

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -110,16 +110,13 @@ class TestWrappers(unittest.TestCase):
     
     def test_anndata(self):
         adata = read_h5ad(join('data', 'test.h5ad'))
-        w = AnnDataWrapper(adata, cell_set_obs_cols=['CellType'])
+        w = AnnDataWrapper(adata, cell_set_obs=['CellType'])
 
-        cells_json = w.create_cells_json()
-        cell_sets_json = w.create_cell_sets_json()
+        obj_file_defs, _ = w.get_cells("http://localhost:8000", 'A', 0)
+        self.assertEqual(obj_file_defs, [{'type': 'cells', 'fileType': 'anndata-cells.zarr', 'url': 'http://localhost:8000/A/0/anndata.zarr', 'options': {'factors': ['obs/CellType']}}])
 
-        obj_file_defs, obj_routes = w.get_cells("http://localhost:8000", 'A', 0)
-        self.assertEqual(obj_file_defs, [{'type': 'cells', 'fileType': 'cells.json', 'url': 'http://localhost:8000/A/0/cells'}])
-
-        obj_file_defs, obj_routes = w.get_cell_sets("http://localhost:8000", 'A', 0)
-        self.assertEqual(obj_file_defs, [{'type': 'cell-sets', 'fileType': 'cell-sets.json', 'url': 'http://localhost:8000/A/0/cell-sets'}])
+        obj_file_defs, _ = w.get_cell_sets("http://localhost:8000", 'A', 0)
+        self.assertEqual(obj_file_defs, [{'type': 'cell-sets', 'fileType': 'anndata-cell-sets.zarr', 'url': 'http://localhost:8000/A/0/anndata.zarr', 'options': [{'groupName': 'CellType', 'setName': 'obs/CellType'}]}])
 
     def test_snaptools(self):
         mtx = mmread(join('data', 'test.snap.mtx'))

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -742,7 +742,7 @@ class VitessceConfig:
             dataset.add_object(obj)
 
             # TODO: use the available embeddings to determine how many / which scatterplots to add.
-            scatterplot = vc.add_view(dataset, cm.SCATTERPLOT, mapping="UMAP")
+            scatterplot = vc.add_view(dataset, cm.SCATTERPLOT, mapping=obj.mappings_obsm[0].split('/')[-1])
             cell_sets = vc.add_view(dataset, cm.CELL_SETS)
             genes = vc.add_view(dataset, cm.GENES)
             heatmap = vc.add_view(dataset, cm.HEATMAP)

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -51,18 +51,21 @@ class VitessceConfigDatasetFile:
     """
     A class to represent a file (described by a URL, data type, and file type) in a Vitessce view config dataset.
     """
-    def __init__(self, url, data_type, file_type):
+    def __init__(self, url, data_type, file_type, options):
         """
         Not meant to be instantiated directly, but instead created and returned by the ``VitessceConfigDataset.add_file()`` method.
 
         :param str url: A URL to this file. Can be a localhost URL or a remote URL.
         :param str data_type: A data type.
         :param str file_type: A file type.
+        :type options: Extra options to pass to the file loader class.
+        :type options: dict or list or None
         """
         self.file = {
             "url": url,
             "type": data_type,
             "fileType": file_type,
+            **({ "options": options } if options is not None else {})
         }
     
     def to_dict(self):
@@ -86,7 +89,7 @@ class VitessceConfigDataset:
         }
         self.objs = []
     
-    def add_file(self, url, data_type, file_type):
+    def add_file(self, url, data_type, file_type, options=None):
         """
         Add a new file definition to this dataset instance.
 
@@ -95,6 +98,8 @@ class VitessceConfigDataset:
         :type data_type: str or vitessce.constants.DataType
         :param file_type: The file type. Must be compatible with the specified data type.
         :type file_type: str or vitessce.constants.FileType
+        :type options: Extra options to pass to the file loader class. Optional.
+        :type options: dict or list or None
 
         :returns: Self, to allow function chaining.
         :rtype: VitessceConfigDataset
@@ -130,7 +135,7 @@ class VitessceConfigDataset:
         else:
             file_type_str = file_type.value
 
-        self.dataset["files"].append(VitessceConfigDatasetFile(url=url, data_type=data_type_str, file_type=file_type_str))
+        self.dataset["files"].append(VitessceConfigDatasetFile(url=url, data_type=data_type_str, file_type=file_type_str, options=options))
         return self
     
     def add_object(self, obj):

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -742,7 +742,7 @@ class VitessceConfig:
             dataset.add_object(obj)
 
             # TODO: use the available embeddings to determine how many / which scatterplots to add.
-            scatterplot = vc.add_view(dataset, cm.SCATTERPLOT, mapping="X_umap")
+            scatterplot = vc.add_view(dataset, cm.SCATTERPLOT, mapping="UMAP")
             cell_sets = vc.add_view(dataset, cm.CELL_SETS)
             genes = vc.add_view(dataset, cm.GENES)
             heatmap = vc.add_view(dataset, cm.HEATMAP)

--- a/vitessce/constants.py
+++ b/vitessce/constants.py
@@ -87,3 +87,7 @@ class FileType(DocEnum):
     RASTER_JSON = "raster.json", "The JSON-based raster manifest file type."
     CELL_SETS_JSON = "cell-sets.json", "The JSON-based cell sets file type."
     GENOMIC_PROFILES_ZARR = "genomic-profiles.zarr", "The Zarr-based genomic profile (multivec) file type."
+    ANNDATA_CELLS_ZARR = "anndata-cells.zarr", "The Zarr-based cells file type from an anndata object."
+    ANNDATA_CELL_SETS_ZARR = "anndata-cell-sets.zarr", "The Zarr-based cell-sets file type from an anndata object."
+    ANNDATA_EXPRESSION_MATRIX_ZARR = "anndata-expression-matrix.zarr", "The Zarr-based expression matrix file type from an anndata object."
+

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -397,8 +397,16 @@ class AnnDataWrapper(AbstractWrapper):
 
         :param adata: An AnnData object containing single-cell experiment data.
         :type adata: anndata.AnnData
-        :param bool use_highly_variable_genes: When creating outputs with genes, should only the genes marked as highly variable be used?
-        :param list[str] cell_set_obs: A list of column names of the ``adata.obs`` dataframe that should be used for creating cell sets.
+        :param str adata_url: A remote url pointing to a zarr-backed AnnData store.
+        :param str expression_matrix: Location of the expression (cell x gene) matrix, like `X` or `obsm/highly_variable_genes_subset`
+        :param str genes_var_filter: A string like `highly_variable` (from `var` in the AnnData stored) used in conjunction with expression_matrix if expression_matrix points to a subset of `X` of the full `var` list.
+        :param list[str] cell_set_obs: Column names like `['louvain', 'cellType'] for showing cell sets from `obs`
+        :param list[str] cell_set_obs_names: Names to display in place of those in `cell_set_obs`, like `['Louvain', 'Cell Type']
+        :param str spatial_centroid_obsm: Column name in `obsm` that contains centroid coordinates for displaying centroids in the spatial viewer
+        :param str spatial_polygon_obsm: Column name in `obsm` that contains polygonal coordinates for displaying outlines in the spatial viewer
+        :param list[str] mappings_obsm: Column names like `['X_umap', 'X_pca'] for showing scatterplots from `obsm`
+        :param list[str] mappings_obsm_names: Overriding names like `['UMAP', 'PCA'] for displaying above scatterplots
+        :param list[str] mappings_obsm_dims: Dimensions along which to get data for the scatterplot, like [[0, 1], [4, 5]] where [0, 1] is just the normal x and y but [4, 5] could be comparing the third and fourth principal components, for example.
         :param \*\*kwargs: Keyword arguments inherited from :class:`~vitessce.wrappers.AbstractWrapper`
         """
         super().__init__(**kwargs)
@@ -419,7 +427,7 @@ class AnnDataWrapper(AbstractWrapper):
         self.spatial_centroid_obsm = "obsm/" + spatial_centroid_obsm if spatial_centroid_obsm is not None else spatial_centroid_obsm
         self.spatial_polygon_obsm = "obsm/" + spatial_polygon_obsm if spatial_polygon_obsm is not None else spatial_polygon_obsm
         self.mappings_obsm = ["obsm/" + i for i in mappings_obsm] if mappings_obsm is not None else mappings_obsm
-        self.mappings_obsm_dims = ["obsm/" + i for i in mappings_obsm_dims] if mappings_obsm_dims is not None else mappings_obsm_dims
+        self.mappings_obsm_dims = mappings_obsm_dims
     
     def _get_zarr_dir(self):
         return os.path.basename(self._zarr_filepath if self._zarr_filepath is not None else self._adata_url)
@@ -454,7 +462,7 @@ class AnnDataWrapper(AbstractWrapper):
                         "dims": [0, 1]
                     }
             if self.mappings_obsm_dims is not None:
-                for key, dim in zip(self.mappings_obsm_dims, self.mappings_obsm_names):
+                for dim, key in zip(self.mappings_obsm_dims, self.mappings_obsm_names):
                     options["mappings"][key]['dims'] = dim
         if self.cell_set_obs is not None:
             options["factors"] = []

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -391,7 +391,7 @@ class OmeZarrWrapper(AbstractWrapper):
 
 
 class AnnDataWrapper(AbstractWrapper):
-    def __init__(self, adata=None, adata_url=None, expression_matrix=None, genes_vars_filter=None, cell_set_obs=None, cell_set_obs_names=None, spatial_centroid_obsm=None, spatial_polygon_obsm=None, mappings_obsm=None, mappings_obsm_names=None, mappings_obsm_dims=None, **kwargs):
+    def __init__(self, adata=None, adata_url=None, expression_matrix=None, genes_var_filter=None, cell_set_obs=None, cell_set_obs_names=None, spatial_centroid_obsm=None, spatial_polygon_obsm=None, mappings_obsm=None, mappings_obsm_names=None, mappings_obsm_dims=None, **kwargs):
         """
         Wrap an AnnData object by creating an instance of the ``AnnDataWrapper`` class.
 
@@ -414,7 +414,7 @@ class AnnDataWrapper(AbstractWrapper):
         self.expression_matrix = expression_matrix
         self.cell_set_obs_names = cell_set_obs_names
         self.mappings_obsm_names = mappings_obsm_names
-        self.genes_vars_filter = "vars/" + genes_vars_filter if genes_vars_filter is not None else genes_vars_filter
+        self.genes_var_filter = "var/" + genes_var_filter if genes_var_filter is not None else genes_var_filter
         self.cell_set_obs = ["obs/" + i for i in cell_set_obs] if cell_set_obs is not None else cell_set_obs
         self.spatial_centroid_obsm = "obsm/" + spatial_centroid_obsm if spatial_centroid_obsm is not None else spatial_centroid_obsm
         self.spatial_polygon_obsm = "obsm/" + spatial_polygon_obsm if spatial_polygon_obsm is not None else spatial_polygon_obsm
@@ -507,8 +507,8 @@ class AnnDataWrapper(AbstractWrapper):
         obj_file_defs = []
         if self.expression_matrix is not None:
             options["matrix"] = self.expression_matrix
-            if self.genes_vars_filter is not None:
-                options["genesFilter"] = self.genes_vars_filter
+            if self.genes_var_filter is not None:
+                options["geneFilter"] = self.genes_var_filter
             obj_file_defs = [
                 {
                     "type": dt.EXPRESSION_MATRIX.value,

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -400,11 +400,11 @@ class AnnDataWrapper(AbstractWrapper):
         :param str adata_url: A remote url pointing to a zarr-backed AnnData store.
         :param str expression_matrix: Location of the expression (cell x gene) matrix, like `X` or `obsm/highly_variable_genes_subset`
         :param str genes_var_filter: A string like `highly_variable` (from `var` in the AnnData stored) used in conjunction with expression_matrix if expression_matrix points to a subset of `X` of the full `var` list.
-        :param list[str] cell_set_obs: Column names like `['louvain', 'cellType'] for showing cell sets from `obs`
+        :param list[str] cell_set_obs: Column names like `['louvain', 'cellType']` for showing cell sets from `obs`
         :param list[str] cell_set_obs_names: Names to display in place of those in `cell_set_obs`, like `['Louvain', 'Cell Type']
         :param str spatial_centroid_obsm: Column name in `obsm` that contains centroid coordinates for displaying centroids in the spatial viewer
         :param str spatial_polygon_obsm: Column name in `obsm` that contains polygonal coordinates for displaying outlines in the spatial viewer
-        :param list[str] mappings_obsm: Column names like `['X_umap', 'X_pca'] for showing scatterplots from `obsm`
+        :param list[str] mappings_obsm: Column names like `['X_umap', 'X_pca']` for showing scatterplots from `obsm`
         :param list[str] mappings_obsm_names: Overriding names like `['UMAP', 'PCA'] for displaying above scatterplots
         :param list[str] mappings_obsm_dims: Dimensions along which to get data for the scatterplot, like [[0, 1], [4, 5]] where [0, 1] is just the normal x and y but [4, 5] could be comparing the third and fourth principal components, for example.
         :param \*\*kwargs: Keyword arguments inherited from :class:`~vitessce.wrappers.AbstractWrapper`

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -496,7 +496,7 @@ class AnnDataWrapper(AbstractWrapper):
         options = {}
 
         if self.expression_matrix is not None:
-            options["matrix"] = expression_matrix
+            options["matrix"] = self.expression_matrix
             if self.genes_filter is not None:
                 options["genesFilter"] = self.genes_filter
         obj_file_defs = [


### PR DESCRIPTION
Here we use Zarr for AnnData, supporting both local anndata objects and remote (zarr) stores. This breaks the current loom example because of a string parsing issue but I have opened an issue in [AnnData](https://github.com/theislab/anndata/issues/491) to make some progress on that.  In the meantime, I am going to clean this up and hopefully get a fix in for that issue so that the client can parse the loom object converted to anndata.