### PR TITLE
Change on_obj Function + Upgrade Vitessce

### DIFF
--- a/docs/notebooks/widget_imaging.ipynb
+++ b/docs/notebooks/widget_imaging.ipynb
@@ -37,30 +37,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1. Set the transformation matrix for the IMS data\n",
-    "We downloaded this transformation from [Globus](https://app.globus.org/file-manager?origin_id=af603d86-eab9-4eec-bb1d-9d26556741bb&origin_path=%2Fd9e3c80a32567cde9b61e38ce8693559%2Fmetadata%2F), the link to which was found through the HuBMAP data portal page for the [IMS dataset](https://portal.hubmapconsortium.org/browse/dataset/d9e3c80a32567cde9b61e38ce8693559)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "transformation_matrix = [\n",
-    "    20,0,0,0,\n",
-    "    0,20,0,0,\n",
-    "    0,0,1,0,\n",
-    "    0,0,0,1\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 2. Configure Vitessce\n",
-    "Set up the images from the three different assays, with the transformation matrix applied to the IMS image."
+    "## 1. Configure Vitessce\n",
+    "Set up the images from the three different assays, with the `use_physical_size_scaling` set to `True` so that the IMS image scales to the other images based on their physical sizes."
    ]
   },
   {
@@ -71,11 +49,13 @@
    "source": [
     "vc = VitessceConfig(name='Spraggins Multi-Modal', description='PAS + IMS + AF From https://portal.hubmapconsortium.org/browse/collection/6a6efd0c1a2681dc7d2faab8e4ab0bca')\n",
     "dataset = vc.add_dataset(name='Spraggins').add_object(\n",
-    "    MultiImageWrapper(image_wrappers=[\n",
-    "        OmeTiffWrapper(img_url='https://assets.hubmapconsortium.org/f4188a148e4c759092d19369d310883b/ometiff-pyramids/processedMicroscopy/VAN0006-LK-2-85-PAS_images/VAN0006-LK-2-85-PAS_registered.ome.tif?token=', name='PAS'),\n",
-    "        OmeTiffWrapper(img_url='https://assets.hubmapconsortium.org/2130d5f91ce61d7157a42c0497b06de8/ometiff-pyramids/processedMicroscopy/VAN0006-LK-2-85-AF_preIMS_images/VAN0006-LK-2-85-AF_preIMS_registered.ome.tif?token=', name='AF'),\n",
-    "        OmeTiffWrapper(img_url='https://assets.hubmapconsortium.org/be503a021ed910c0918842e318e6efa2/ometiff-pyramids/ometiffs/VAN0006-LK-2-85-IMS_PosMode_multilayer.ome.tif?token=', transformation_matrix=transformation_matrix, name='IMS')\n",
-    "    ]\n",
+    "    MultiImageWrapper(\n",
+    "        image_wrappers=[\n",
+    "            OmeTiffWrapper(img_url='https://assets.hubmapconsortium.org/f4188a148e4c759092d19369d310883b/ometiff-pyramids/processedMicroscopy/VAN0006-LK-2-85-PAS_images/VAN0006-LK-2-85-PAS_registered.ome.tif?token=', name='PAS'),\n",
+    "            OmeTiffWrapper(img_url='https://assets.hubmapconsortium.org/2130d5f91ce61d7157a42c0497b06de8/ometiff-pyramids/processedMicroscopy/VAN0006-LK-2-85-AF_preIMS_images/VAN0006-LK-2-85-AF_preIMS_registered.ome.tif?token=', name='AF'),\n",
+    "            OmeTiffWrapper(img_url='https://assets.hubmapconsortium.org/be503a021ed910c0918842e318e6efa2/ometiff-pyramids/ometiffs/VAN0006-LK-2-85-IMS_PosMode_multilayer.ome.tif?token=', name='IMS')\n",
+    "        ],\n",
+    "        use_physical_size_scaling=True,\n",
     " )\n",
     ")\n",
     "spatial = vc.add_view(dataset, cm.SPATIAL)\n",
@@ -88,7 +68,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. Create the Vitessce widget"
+    "## 2. Create the Vitessce widget"
    ]
   },
   {

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1256,20 +1256,21 @@
       }
     },
     "@deck.gl/geo-layers": {
-      "version": "8.4.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.4.0-alpha.4.tgz",
-      "integrity": "sha512-CE0SdpibxjaQcVljxT1iZOJKY66acJro3pfDhVGIg4o7A8enGHIIkK9Pk1FnmNbATvFkWHGzet5T3yKFleuwMw==",
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.4.4.tgz",
+      "integrity": "sha512-vqtjR3uCHFE9Et01G0HDuMqA1+XXwp/HSW++5UqVsqRwhoFK3Uan4AE2VII4CmKk8obz+5ulNWQzp/WJLxZKRA==",
       "requires": {
         "@loaders.gl/3d-tiles": "^2.3.0",
+        "@loaders.gl/gis": "^2.3.0",
         "@loaders.gl/loader-utils": "^2.3.0",
         "@loaders.gl/mvt": "^2.3.0",
         "@loaders.gl/terrain": "^2.3.0",
         "@loaders.gl/tiles": "^2.3.0",
-        "@math.gl/culling": "^3.3.2",
-        "@math.gl/web-mercator": "^3.3.2",
+        "@math.gl/culling": "^3.4.2",
+        "@math.gl/web-mercator": "^3.4.2",
         "h3-js": "^3.6.0",
         "long": "^3.2.0",
-        "math.gl": "^3.3.2"
+        "math.gl": "^3.4.2"
       }
     },
     "@deck.gl/google-maps": {
@@ -1303,18 +1304,19 @@
       "integrity": "sha512-K00RIkHV+S3USjc9JkoJbrJYd9PalPWlyPjYUo0B6/GrOyO2Dlz4mJ+rpYxM0qogqPhj3VuKzRGvLORsaAT42A=="
     },
     "@deck.gl/mesh-layers": {
-      "version": "8.4.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.4.0-alpha.4.tgz",
-      "integrity": "sha512-QX0fN/VtjARuvsLmwgw+ANYAX2RKUXGIKIpwaRSv89YSgvZWnQqlrisUEw65K6yxB2Ms4SUnvk5f39co0ZD2Qg==",
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.4.4.tgz",
+      "integrity": "sha512-q4idEzsIWpcobH7Hb65vGgCSTgk4Jxhx3KakPyYwPImqeh3ZrTs4gxuC5mydMjx21blj3Th+RFDfISX7BsptUw==",
       "requires": {
-        "@luma.gl/experimental": "^8.3.1",
-        "@luma.gl/shadertools": "^8.3.1"
+        "@loaders.gl/gltf": "^2.3.0",
+        "@luma.gl/experimental": "^8.4.1",
+        "@luma.gl/shadertools": "^8.4.1"
       }
     },
     "@deck.gl/react": {
-      "version": "8.4.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.4.0-alpha.4.tgz",
-      "integrity": "sha512-u7r1MXnexp52HdOepmZSNEN+41xl6kW2Hpz5XfDs/IhuhNx/TTFkxzOx6h/c2iAg+1VprxZsz4R8NMaARYxX8g==",
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.4.4.tgz",
+      "integrity": "sha512-Pi+MiPd+DBLrHjDF1SbYAzVa4nMWjF9Zr7bstw6Q6AMlluVj/1gTFIsQRlKduQuXD00eg3+KZEos4lWMnyJe2w==",
       "requires": {
         "prop-types": "^15.6.0"
       }
@@ -1325,9 +1327,9 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@hms-dbmi/viv": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.8.2.tgz",
-      "integrity": "sha512-+p5NW7vz66TrCZczcNle3f6tzBhBCxwsUNSwZvE/tfB9D3Dh9ASksymhQFR1TijmpyWNQdsOTj6Q0yO17TcSxg==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.8.3.tgz",
+      "integrity": "sha512-cVpCW1SU8I+cr3PNDQfgLseGdB2sS6N47CPwV413hIYyU3qRxbbZvAS52PfYDKf2IEkb/C7LeKnugym0JaaC6A==",
       "requires": {
         "@deck.gl/core": "^8.4.0-alpha.3",
         "@deck.gl/geo-layers": "^8.4.0-alpha.3",
@@ -1337,8 +1339,9 @@
         "@luma.gl/constants": "^8.3.1",
         "@luma.gl/core": "^8.3.1",
         "@luma.gl/shadertools": "^8.3.1",
+        "fast-deep-equal": "^3.1.3",
         "fast-xml-parser": "^3.16.0",
-        "geotiff": "github:ilan-gold/geotiff.js#ilan-gold/viv_release_080",
+        "geotiff": "github:ilan-gold/geotiff.js#ilan-gold/viv_083",
         "math.gl": "^3.3.0",
         "quickselect": "^2.0.0",
         "zarr": "^0.3.0"
@@ -1446,118 +1449,118 @@
       }
     },
     "@loaders.gl/3d-tiles": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-2.3.7.tgz",
-      "integrity": "sha512-Dw+bjkO4BUEcJUXB7iAlh2RzaDWjDFTvqiUW+WPT+2WSUjD8EAVZ1WIo/cQFK5DgulLRO09dYlRTPlo6WuNpfQ==",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-2.3.11.tgz",
+      "integrity": "sha512-EISLGrnEvmF2n19L4ac/wNXWR/mHNcRjxiAu9fmfl6EAwBEb6HM2Pvo/VodWwHHkj+YJQrx4RoMFpDHBswyJ2A==",
       "requires": {
-        "@loaders.gl/core": "2.3.7",
-        "@loaders.gl/draco": "2.3.7",
-        "@loaders.gl/gltf": "2.3.7",
-        "@loaders.gl/loader-utils": "2.3.7",
-        "@loaders.gl/math": "2.3.7",
-        "@loaders.gl/tiles": "2.3.7",
+        "@loaders.gl/core": "2.3.11",
+        "@loaders.gl/draco": "2.3.11",
+        "@loaders.gl/gltf": "2.3.11",
+        "@loaders.gl/loader-utils": "2.3.11",
+        "@loaders.gl/math": "2.3.11",
+        "@loaders.gl/tiles": "2.3.11",
         "@math.gl/core": "^3.3.0",
         "@math.gl/geospatial": "^3.3.0",
         "@probe.gl/stats": "^3.3.0"
       }
     },
     "@loaders.gl/core": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-2.3.7.tgz",
-      "integrity": "sha512-jFKhN2+7JwyoIRzJ0YtWHqjhFtVRum7HVqFqVcz8I8NosB5LEdswnnpGVxTtM5XLIaixdGzfH8i8jq37Kpg0Ag==",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-2.3.11.tgz",
+      "integrity": "sha512-3lmoLy/JiSZQV7oTFcfNrYYonXghEBeEJFK0DHa/AinWVw7Ikz/MK2r3Z4MXElE/tnXPYN/AeLqkfDdwG8Nk1g==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "2.3.7"
+        "@loaders.gl/loader-utils": "2.3.11"
       }
     },
     "@loaders.gl/draco": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-2.3.7.tgz",
-      "integrity": "sha512-sY0Kbfm6k6BuzMeMJZLYh/c/FKqZ7T3OU/gDsK5s+OPoKYgu64qnBWhRs1Yx3acOfRNVR7iGE2x5q2MBpu1F/g==",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-2.3.11.tgz",
+      "integrity": "sha512-MllCmZO3hP9MYNfSAFn83jrD/QbMt5IMftSMf1HArzYDt/yWkPp3VXayV5WjTyoZby8AJYweE8GhPqWIa869fQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "2.3.7",
+        "@loaders.gl/loader-utils": "2.3.11",
         "draco3d": "^1.3.6"
       }
     },
     "@loaders.gl/gis": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-2.3.7.tgz",
-      "integrity": "sha512-zQAWKedBBJECK2+TokMfu7rV//Kv9nGNCYwulu+221bP1XmJz9SgdsWMj3RuSALVPet/ia/RV3Mdg4p324SKUA==",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-2.3.11.tgz",
+      "integrity": "sha512-MdJ7/nISfi/VQGZtbE+zDIvTMhENOduSU8V7YCbvM2gZqn2eRqWq7hbH9bPxxS8EnhXeKaF2Vp8cw4VR/YOutQ==",
       "requires": {
-        "@loaders.gl/loader-utils": "2.3.7",
+        "@loaders.gl/loader-utils": "2.3.11",
         "@mapbox/vector-tile": "^1.3.1",
         "pbf": "^3.2.1"
       }
     },
     "@loaders.gl/gltf": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-2.3.7.tgz",
-      "integrity": "sha512-M/4Fwht+/GWKG8YM74YFo7e+6MJdmHKGbl7kqerjSKHBOGAU16VUTTIgtPNzTyFFNwmJz/umZ5gfvz7fTC/+2g==",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-2.3.11.tgz",
+      "integrity": "sha512-IMLJMie4Pc20AxnwTw5dXJRrszxSldTgPO2HfSf9ZSxYELF+B1yjec5rDGON0HZ+nMN3rCK/4Z2r/gf7w3Qbpg==",
       "requires": {
-        "@loaders.gl/core": "2.3.7",
-        "@loaders.gl/draco": "2.3.7",
-        "@loaders.gl/images": "2.3.7",
-        "@loaders.gl/loader-utils": "2.3.7"
+        "@loaders.gl/core": "2.3.11",
+        "@loaders.gl/draco": "2.3.11",
+        "@loaders.gl/images": "2.3.11",
+        "@loaders.gl/loader-utils": "2.3.11"
       }
     },
     "@loaders.gl/images": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-2.3.7.tgz",
-      "integrity": "sha512-JMLXyjUEZz6MuCmeQtXYfiH6+SOkvUZ2uS36HaYl7aPshq3pIRJd8EBu9FuB3ObK8V7E3zqZKbtoQW9lAASWPg==",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-2.3.11.tgz",
+      "integrity": "sha512-Kb2lQZQgOTh/DMbWQmkMfsilyQamSJqDTZDoJKbXM6x3P+O9cLuMZXE6KQrq80z5Ax1BcC7nGcn+hNq5904ADA==",
       "requires": {
-        "@loaders.gl/loader-utils": "2.3.7"
+        "@loaders.gl/loader-utils": "2.3.11"
       }
     },
     "@loaders.gl/loader-utils": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-2.3.7.tgz",
-      "integrity": "sha512-PYjlt7UmUNqAb/F/52Om/hJt6yEZdIH6ucH+145kEKBTqVR45z5K1/3DrNjQg0Ofo9yUMbVGdtACT4mVlbBrzg==",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-2.3.11.tgz",
+      "integrity": "sha512-PE9dhBdw/GuH7ZHrVkhy9wdCTXJ7/nvMhMjL91E0bJ206TvPO+vGDMtIu9QFqt254PE5oU35MJS5bbB/Bgs5kQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "@probe.gl/stats": "^3.3.0"
       }
     },
     "@loaders.gl/math": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-2.3.7.tgz",
-      "integrity": "sha512-R1DoMgiDqzkGJb9QYA9vr9N2WksWC5TOGbIWeo8YZ6xhOrkoGEdAflEXPQkKIxoG8UBOdLmchRYbsLOblx8Rog==",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-2.3.11.tgz",
+      "integrity": "sha512-UkDsnixFMpvgNqgj0dvYj/dpeTmiknHL7Q9NtB9IhFEQ21hHlwvcx1iRWAAgOAyooYACmkI45A/JdMv0XnKeGw==",
       "requires": {
-        "@loaders.gl/images": "2.3.7",
-        "@loaders.gl/loader-utils": "2.3.7",
+        "@loaders.gl/images": "2.3.11",
+        "@loaders.gl/loader-utils": "2.3.11",
         "@math.gl/core": "^3.3.0"
       }
     },
     "@loaders.gl/mvt": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-2.3.7.tgz",
-      "integrity": "sha512-LiaRODNHHhx9OeVRHzFp7rayQJx3y6MhLwuGUhj1VJA8wzlC5c/s/SuHTHL331zUj6QiBMtHXOYXYYn/hx1ShA==",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-2.3.11.tgz",
+      "integrity": "sha512-2T6aA8g8schuAHKqFTE0Cba3K4siWy510gorXurdbExG132wD+zGltZnF3w7GaZ+ijx/j3LYHtHrG/d0j7OeLw==",
       "requires": {
-        "@loaders.gl/gis": "2.3.7",
-        "@loaders.gl/loader-utils": "2.3.7",
+        "@loaders.gl/gis": "2.3.11",
+        "@loaders.gl/loader-utils": "2.3.11",
         "@mapbox/point-geometry": "~0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
         "pbf": "^3.2.1"
       }
     },
     "@loaders.gl/terrain": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-2.3.7.tgz",
-      "integrity": "sha512-CNHVeJjMeADPXhyImXIZ0Wmn07ZvqIB+CfPQI419fvZj7gQQ8G/Nmv8B85rU4vYO5xaFtosBhaiHQMqBO34klQ==",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-2.3.11.tgz",
+      "integrity": "sha512-PiK9aXbt4W/c/ufT5mms0HuZmcPvVIDNEqSKKgkQE2kRAFgUOoYBS1XHGFUn5/iS/aWD6K7uOBOk3B6Og8GwPA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "2.3.7",
+        "@loaders.gl/loader-utils": "2.3.11",
         "@mapbox/martini": "^0.2.0"
       }
     },
     "@loaders.gl/tiles": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-2.3.7.tgz",
-      "integrity": "sha512-k+lXRIa2FerwE4cJmYFqKqtSNQtlr0Q/p7qOoyAGdhYk5sWy33ZYrpbvVn+aVZOCTaBNLnm7sivq0sMZpjB9ig==",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-2.3.11.tgz",
+      "integrity": "sha512-OOR7eLWzUy+nLDmKkkrIJjXzXXCzcPWfWvOOsODmPQKrNLBqq3CE4taC0PFj4ABYdkDZmojoLky1Kw8W6sqHig==",
       "requires": {
-        "@loaders.gl/core": "2.3.7",
-        "@loaders.gl/loader-utils": "2.3.7",
-        "@loaders.gl/math": "2.3.7",
+        "@loaders.gl/core": "2.3.11",
+        "@loaders.gl/loader-utils": "2.3.11",
+        "@loaders.gl/math": "2.3.11",
         "@math.gl/core": "^3.3.0",
         "@math.gl/culling": "^3.3.0",
         "@math.gl/geospatial": "^3.3.0",
@@ -1566,73 +1569,74 @@
       }
     },
     "@luma.gl/constants": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.3.2.tgz",
-      "integrity": "sha512-KSNNXv5eE9bkMH2AcZpLysqNEU0SDDZ8JthjHtkdVyOSr4yMeAaRXyWeSuLJITiemXkm4Um8jX6Ub12OW9JPug=="
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.4.2.tgz",
+      "integrity": "sha512-I+grS7erjxtAf6JJqDwPmGbfJTCelqwmhH6TyHOAJfhPiHtnqZ25GoPfZyI+Dj+mUH9FPPmKsU5Yb11p5w02FA=="
     },
     "@luma.gl/core": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-8.3.2.tgz",
-      "integrity": "sha512-VNFAI0o54+e5biugtz19p2Mapv2xFTZ3qqtWE4xwqst4K/HqvWhoBcWsS5NYlzD6ipsUWTlaidA4ROkbFJINMw==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-8.4.2.tgz",
+      "integrity": "sha512-SuhliP/wppKohArjVyTEEuh1RX5Vvd5/g8I7a2ltf1uG4QP/W+qOc1sYKbfbgFGjGBF13PTftUFcwB7qfaCr+A==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.3.2",
-        "@luma.gl/engine": "8.3.2",
-        "@luma.gl/shadertools": "8.3.2",
-        "@luma.gl/webgl": "8.3.2"
+        "@luma.gl/constants": "8.4.2",
+        "@luma.gl/engine": "8.4.2",
+        "@luma.gl/gltools": "8.4.2",
+        "@luma.gl/shadertools": "8.4.2",
+        "@luma.gl/webgl": "8.4.2"
       }
     },
     "@luma.gl/engine": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-8.3.2.tgz",
-      "integrity": "sha512-9msfc/7HemWrCyIbBH9FA3LgOeaPhuit9e+YcEw3UCAo+6AY/+V1EAawne1Lvd4lXgNQb3L8L5yAP60Qr8rGxA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-8.4.2.tgz",
+      "integrity": "sha512-/cr7MLDIBPzrqUrD4rViESi+sGLV00iMFxxz8CY2Lbz9Qr5MxjUKNBhAVyfJL0hCTvz5Ejpiw7Thvupnm0JdoQ==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.3.2",
-        "@luma.gl/gltools": "8.3.2",
-        "@luma.gl/shadertools": "8.3.2",
-        "@luma.gl/webgl": "8.3.2",
-        "math.gl": "^3.3.0",
+        "@luma.gl/constants": "8.4.2",
+        "@luma.gl/gltools": "8.4.2",
+        "@luma.gl/shadertools": "8.4.2",
+        "@luma.gl/webgl": "8.4.2",
+        "@math.gl/core": "^3.4.2",
         "probe.gl": "^3.2.1"
       }
     },
     "@luma.gl/experimental": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@luma.gl/experimental/-/experimental-8.3.2.tgz",
-      "integrity": "sha512-X0Qv7KUNT311ec6/TQzv4LXvcLpsF62+CurjBQ/vXmpHAhWU7Ufx2Vhab43rrkHvoUXnSmQL62I8HBDtaTL/fw==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@luma.gl/experimental/-/experimental-8.4.2.tgz",
+      "integrity": "sha512-m0UMeNJnx1DrrEp1Nfkl0u3MNLgKNoZdVln6Z0nVvbwMSCyjb04AASHiFa+WgUrQ45ky4D3Rudhhms2z5ROvfg==",
       "requires": {
-        "@luma.gl/constants": "8.3.2",
-        "earcut": "^2.0.6",
-        "math.gl": "^3.3.0"
+        "@luma.gl/constants": "8.4.2",
+        "@math.gl/core": "^3.4.1",
+        "earcut": "^2.0.6"
       }
     },
     "@luma.gl/gltools": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@luma.gl/gltools/-/gltools-8.3.2.tgz",
-      "integrity": "sha512-JGsVdFkr9o74nn1D8vf9huW1hcZiGNAhOtA2jAv9GG4oHPIKLRN8p95QroYMFYl/DcfAxXNR+Mq7hPiTtDiw9w==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@luma.gl/gltools/-/gltools-8.4.2.tgz",
+      "integrity": "sha512-sXpY0dUv4eQpvsryvHsnLBdjdpqiGcyaSKshmSZ7lweyy8znGGqpu0TDyH3vqzhl/76d6sWnJ/ZE5ocqgDavIg==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.3.2",
+        "@luma.gl/constants": "8.4.2",
         "probe.gl": "^3.2.1"
       }
     },
     "@luma.gl/shadertools": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-8.3.2.tgz",
-      "integrity": "sha512-XEAPtEyfcrL9qNdv/xUxxFRmxYwx+LEJMyJ0rUGEZL17a1JMUsyW1B+5EnoNPQEMY4mL1vpa83qHPHX5gYw1FA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-8.4.2.tgz",
+      "integrity": "sha512-KVZzKAA+SkYgdZ+yWSRLZ/eLAE6aEa7m2y26TuVrUEXMnO8mo0kBCU1jC7MwVvSZF479Hl3DDD30WfSNm3UX2Q==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "math.gl": "^3.3.0"
+        "@math.gl/core": "^3.4.2"
       }
     },
     "@luma.gl/webgl": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-8.3.2.tgz",
-      "integrity": "sha512-mO3/DCCs/VlQbjFbqGE6FlGX/qU6pdMtS26JBCAV30dR40LO41uWWEz9HniDv92QPDPb+ZNCa5/yYbtLpZnADw==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-8.4.2.tgz",
+      "integrity": "sha512-eN2AoF1/8lcfRF+ruuPX7oBxJE0kDDqk7nK2M6Zqy/LnUhGekSxXll9j4eqWfoFtOJnkGZNJPrKgsOfRQgmdPw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.3.2",
-        "@luma.gl/gltools": "8.3.2",
+        "@luma.gl/constants": "8.4.2",
+        "@luma.gl/gltools": "8.4.2",
         "probe.gl": "^3.2.1"
       }
     },
@@ -1765,9 +1769,9 @@
       "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
     },
     "@mapbox/tiny-sdf": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.1.tgz",
-      "integrity": "sha512-Ihn1nZcGIswJ5XGbgFAvVumOgWpvIjBX9jiRlIl46uQG9vJOF51ViBYHF95rEZupuyQbEmhLaDPLQlU7fUTsBg=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.3.tgz",
+      "integrity": "sha512-UH233on+8Okmj/JJFcxyc+HMSzKQcSFiiT339lFf2BMGs0+iEbobX7+GESeKVkPVtTFoh54LuNa1mC8N2ucM2w=="
     },
     "@mapbox/vector-tile": {
       "version": "1.3.1",
@@ -1778,13 +1782,13 @@
       }
     },
     "@material-ui/core": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.2.tgz",
-      "integrity": "sha512-/D1+AQQeYX/WhT/FUk78UCRj8ch/RCglsQLYujYTIqPSJlwZHKcvHidNeVhODXeApojeXjkl0tWdk5C9ofwOkQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.3.tgz",
+      "integrity": "sha512-Adt40rGW6Uds+cAyk3pVgcErpzU/qxc7KBR94jFHBYretU4AtWZltYcNsbeMn9tXL86jjVL1kuGcIHsgLgFGRw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.11.2",
-        "@material-ui/system": "^4.11.2",
+        "@material-ui/styles": "^4.11.3",
+        "@material-ui/system": "^4.11.3",
         "@material-ui/types": "^5.1.0",
         "@material-ui/utils": "^4.11.2",
         "@types/react-transition-group": "^4.2.0",
@@ -1805,9 +1809,9 @@
       }
     },
     "@material-ui/styles": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.2.tgz",
-      "integrity": "sha512-xbItf8zkfD3FuGoD9f2vlcyPf9jTEtj9YTJoNNV+NMWaSAHXgrW6geqRoo/IwBuMjqpwqsZhct13e2nUyU9Ljw==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.3.tgz",
+      "integrity": "sha512-HzVzCG+PpgUGMUYEJ2rTEmQYeonGh41BYfILNFb/1ueqma+p1meSdu4RX6NjxYBMhf7k+jgfHFTTz+L1SXL/Zg==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@emotion/hash": "^0.8.0",
@@ -1816,21 +1820,21 @@
         "clsx": "^1.0.4",
         "csstype": "^2.5.2",
         "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.0.3",
-        "jss-plugin-camel-case": "^10.0.3",
-        "jss-plugin-default-unit": "^10.0.3",
-        "jss-plugin-global": "^10.0.3",
-        "jss-plugin-nested": "^10.0.3",
-        "jss-plugin-props-sort": "^10.0.3",
-        "jss-plugin-rule-value-function": "^10.0.3",
-        "jss-plugin-vendor-prefixer": "^10.0.3",
+        "jss": "^10.5.1",
+        "jss-plugin-camel-case": "^10.5.1",
+        "jss-plugin-default-unit": "^10.5.1",
+        "jss-plugin-global": "^10.5.1",
+        "jss-plugin-nested": "^10.5.1",
+        "jss-plugin-props-sort": "^10.5.1",
+        "jss-plugin-rule-value-function": "^10.5.1",
+        "jss-plugin-vendor-prefixer": "^10.5.1",
         "prop-types": "^15.7.2"
       }
     },
     "@material-ui/system": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.2.tgz",
-      "integrity": "sha512-BELFJEel5E+5DMiZb6XXT3peWRn6UixRvBtKwSxqntmD0+zwbbfCij6jtGwwdJhN1qX/aXrKu10zX31GBaeR7A==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.3.tgz",
+      "integrity": "sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@material-ui/utils": "^4.11.2",
@@ -1854,18 +1858,18 @@
       }
     },
     "@math.gl/core": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.4.1.tgz",
-      "integrity": "sha512-miAZL/WPU0B5hKrcg1K2nPU2GnOK6X84bwLoD0eTt2n7qT46ffh51Xu21V9kQp/cisE3l1ypukqSV/VHeaNxhQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.4.2.tgz",
+      "integrity": "sha512-65vhtokCDq0N16DLwWZhPTNAGuVtTjyyi5tx950yNN3ei5BRxz2JHe6JTSnjjKO/2w9KuQYOOqokc7ARog0vKg==",
       "requires": {
         "@babel/runtime": "^7.12.0",
         "gl-matrix": "^3.0.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
+          "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -1873,19 +1877,19 @@
       }
     },
     "@math.gl/culling": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@math.gl/culling/-/culling-3.4.1.tgz",
-      "integrity": "sha512-LnI640xiK7lNLsesl5iK/gzNgFUDvWq2f39qgrwctuj961NCVFIzNSGTl5BMHmMQYKZY+5ZvZKzgO9dpqaqAzw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@math.gl/culling/-/culling-3.4.2.tgz",
+      "integrity": "sha512-rjDfJp58jvTzMjX954/EMdcaVrX8UkkkXWXc1PU2+XFyAtaBYHDk7jiaFQQbBx8sqk9PKd62j3UTwtSreWyoyQ==",
       "requires": {
         "@babel/runtime": "^7.12.0",
-        "@math.gl/core": "3.4.1",
+        "@math.gl/core": "3.4.2",
         "gl-matrix": "^3.0.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
+          "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -1893,19 +1897,19 @@
       }
     },
     "@math.gl/geospatial": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@math.gl/geospatial/-/geospatial-3.4.1.tgz",
-      "integrity": "sha512-UZbkPO1KMs1+K5iICs1Vhy8mHRNpIbJMvLZagKFqkL4279s9gmO1z01TCp6EprXLgA1VCqjZLKj8sW4LMBSmtw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@math.gl/geospatial/-/geospatial-3.4.2.tgz",
+      "integrity": "sha512-EiCwU3B4ftrUsPPHmLqJuxo37Y7Fvi9Mqpvxj6PvdvsF8EmEvMdYgiQXSNL9vSq5JbEy9xWL2ph47wvkWFoWUQ==",
       "requires": {
         "@babel/runtime": "^7.12.0",
-        "@math.gl/core": "3.4.1",
+        "@math.gl/core": "3.4.2",
         "gl-matrix": "^3.0.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
+          "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -1913,26 +1917,26 @@
       }
     },
     "@math.gl/polygon": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.4.1.tgz",
-      "integrity": "sha512-MsL3yeBmuKjMxTk//JUScsMKHU7X5P2JhJ6iml0V8juxRp2GcuVmxM4pKHQpukbnAvDDsIXypuxBuaWkmurB5A==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.4.2.tgz",
+      "integrity": "sha512-ANbZmcrzavzEe0bHbdEYyiudPdGGV/quB3FxUJa3L1QCcZbnrqvnuwqX+8U8ltIDhbACG1x0Uxefwo8p77aMNw==",
       "requires": {
-        "@math.gl/core": "3.4.1"
+        "@math.gl/core": "3.4.2"
       }
     },
     "@math.gl/web-mercator": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.4.1.tgz",
-      "integrity": "sha512-5LAVmo5U25GY5YIxbI3D0J7r97B9AM5pAcWxnF9YhJx44DSVAYfMdiSISOfS+ivKuBFX44mFZvV9j75QY5aDkQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.4.2.tgz",
+      "integrity": "sha512-Az/WI8vxbqnrTEcYgqDQ3CgCRoFA2a4XT9mkjVrT7iIlfrUF5lrIXcmpljjKvoFNBldKrng7hFSeHHM2ghgSrg==",
       "requires": {
         "@babel/runtime": "^7.12.0",
         "gl-matrix": "^3.0.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
+          "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2032,165 +2036,110 @@
         "@babel/runtime": "^7.0.0"
       }
     },
-    "@turf/area": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.0.1.tgz",
-      "integrity": "sha512-Zv+3N1ep9P5JvR0YOYagLANyapGWQBh8atdeR3bKpWcigVXFsEKNUw03U/5xnh+cKzm7yozHD6MFJkqQv55y0g==",
-      "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/meta": "6.x"
-      }
-    },
     "@turf/bbox": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.0.1.tgz",
-      "integrity": "sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.3.0.tgz",
+      "integrity": "sha512-N4ue5Xopu1qieSHP2MA/CJGWHPKaTrVXQJjzHRNcY1vtsO126xbSaJhWUrFc5x5vVkXp0dcucGryO0r5m4o/KA==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/meta": "6.x"
+        "@turf/helpers": "^6.3.0",
+        "@turf/meta": "^6.3.0"
       }
     },
     "@turf/bbox-polygon": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-6.0.1.tgz",
-      "integrity": "sha512-f6BK6GOzUNjmJeOYHklk/5LNcQMQbo51gvAM10dTM5IqzKP01KM5bgV88uOKfSZB0HRQVpaRV1tgXk2bg5cPRg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-6.3.0.tgz",
+      "integrity": "sha512-CCyTBM8LzGRu/lReNlgDyjRO8NojtJ7EPPvSl3bdKQbNFsCm25gwe7Y3xsaCkWLNn5g89lQJI9Izf9xdEsENjQ==",
       "requires": {
-        "@turf/helpers": "6.x"
+        "@turf/helpers": "^6.3.0"
       }
     },
     "@turf/bearing": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.0.1.tgz",
-      "integrity": "sha512-mXY1NozqV9EFfBTbUItujwfqfQF0G/Xe2fzvnZle90ekPEUfhi4Dgf5JswJTd96J9LiT8kcd6Jonp5khnx0wIg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.3.0.tgz",
+      "integrity": "sha512-apuUm9xN6VQLO33m7F2mmzlm3dHfeesJjMSzh9iehGtgmp1IaVndjdcIvs0ieiwm8bN9UhwXpfPtO3pV0n9SFw==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x"
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0"
       }
     },
     "@turf/boolean-clockwise": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
-      "integrity": "sha1-MwK32sYsXikaB4nimvcoM4f6nes=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-6.3.0.tgz",
+      "integrity": "sha512-zW0j8uPjBS5QJqNmJIeatTH02E1S7OCuBNBvkoOUPifC/c2xJ120a1r73prBj1zMFr6k3UCjwG9V8whUMxIAYA==",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      },
-      "dependencies": {
-        "@turf/helpers": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
-        },
-        "@turf/invariant": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
-          "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        }
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0"
       }
     },
     "@turf/boolean-contains": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-6.0.1.tgz",
-      "integrity": "sha512-usAexEdWu7dV43paowGSFEM0PljexnlOuj09HF/VDZwO3FKelwUovF2ymetYatuG7KcIYcexeNEkQ5qQnGExlw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-6.3.0.tgz",
+      "integrity": "sha512-1MW7B5G5tIu1lnAv3pXyFzl75wfBYnbA2GhwHDb4okIXMhloy/r5uIqAZHo0fOXykKVJS/gIfA/MioKIftoTug==",
       "requires": {
-        "@turf/bbox": "6.x",
-        "@turf/boolean-point-in-polygon": "6.x",
-        "@turf/boolean-point-on-line": "6.x",
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x"
+        "@turf/bbox": "^6.3.0",
+        "@turf/boolean-point-in-polygon": "^6.3.0",
+        "@turf/boolean-point-on-line": "^6.3.0",
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0"
       }
     },
     "@turf/boolean-overlap": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-6.0.1.tgz",
-      "integrity": "sha512-Ud6a75BzNYICVc5/Pf/GJ/3M5XZci6AOGlBNUPvhUrG4nT4NNYeXIpVrx1FB/tAg8EwZZXlhwSO26CTDC13XlA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-6.3.0.tgz",
+      "integrity": "sha512-rWh8JKTqlJ1m27FY8YeWcGoXutLyCVfSi2/8AOkXi2F+36P9GM4tHz19yKY3btbnHJTgSZf1xO2YhX2d0BmNqg==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/line-intersect": "6.x",
-        "@turf/line-overlap": "6.x",
-        "@turf/meta": "6.x",
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0",
+        "@turf/line-intersect": "^6.3.0",
+        "@turf/line-overlap": "^6.3.0",
+        "@turf/meta": "^6.3.0",
         "geojson-equality": "0.1.6"
       }
     },
     "@turf/boolean-point-in-polygon": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.0.1.tgz",
-      "integrity": "sha512-FKLOZ124vkJhjzNSDcqpwp2NvfnsbYoUOt5iAE7uskt4svix5hcjIEgX9sELFTJpbLGsD1mUbKdfns8tZxcMNg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.3.0.tgz",
+      "integrity": "sha512-NqFSsoE6OwhDK19IllDQRhEQEkF7UVEOlqH9vgS1fGg4T6NcyKvACJs05c9457tL7QSbV9ZS53f2qiLneFL+qg==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x"
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0"
       }
     },
     "@turf/boolean-point-on-line": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-6.0.1.tgz",
-      "integrity": "sha512-Vl724Tzh4CF/13kgblOAQnMcHagromCP1EfyJ9G/8SxpSoTYeY2G6FmmcpbW51GqKxC7xgM9+Pck50dun7oYkg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-6.3.0.tgz",
+      "integrity": "sha512-eScH8sfKJVjfbEX5Hgkt1nA7A8DUoiYD1riUVqTp2xikujrMfnYRjFpL/UAo01v33cPKZlhCXp7NE86bdOSrYg==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x"
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0"
       }
     },
     "@turf/boolean-within": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-6.0.1.tgz",
-      "integrity": "sha512-fAzDoWzA4UvUE99G8VqQjVg+PSrPBACM9+SLcl0vkbxIhTjoknpTUwSfH86EgKiCkTDttiDIs/q27xZ4H+mgLQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-6.3.0.tgz",
+      "integrity": "sha512-8XtVbzPp6J+lqZtDWVyIwSyVAVcnuie82ub56JEAhCf9w8FX5Db3qXQ76pFcOyy/woeXLZY/nIR58Q79PusrRw==",
       "requires": {
-        "@turf/bbox": "6.x",
-        "@turf/boolean-point-in-polygon": "6.x",
-        "@turf/boolean-point-on-line": "6.x",
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x"
+        "@turf/bbox": "^6.3.0",
+        "@turf/boolean-point-in-polygon": "^6.3.0",
+        "@turf/boolean-point-on-line": "^6.3.0",
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0"
       }
     },
     "@turf/buffer": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
-      "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-6.3.0.tgz",
+      "integrity": "sha512-B0GWgJzmTaaw1GvTd+Df+ToKSYphz9d6hPCOwXbE2vS5DdZryoxBfxQ32LSX/hW/vx7TLf7E4M0VJBb+Sn1DKA==",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/projection": "^5.1.5",
+        "@turf/bbox": "^6.3.0",
+        "@turf/center": "^6.3.0",
+        "@turf/helpers": "^6.3.0",
+        "@turf/meta": "^6.3.0",
+        "@turf/projection": "^6.3.0",
         "d3-geo": "1.7.1",
         "turf-jsts": "*"
       },
       "dependencies": {
-        "@turf/bbox": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
-          "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/center": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
-          "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/helpers": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
-        },
-        "@turf/meta": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
-          "integrity": "sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
         "d3-array": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
@@ -2207,583 +2156,308 @@
       }
     },
     "@turf/center": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/center/-/center-6.0.1.tgz",
-      "integrity": "sha512-bh/SLBwRC2QYcbVOxMFBtiARuMzMzfh4YuVtguYAjyBEIA4HXnnEZT+yZlzfcG3oikG7XgV8vg9eegcmwQe+MQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-6.3.0.tgz",
+      "integrity": "sha512-41g/ZYwoBs2PK7tpAHhf4D6llHdRvY827HLXCld5D0IOnzsWPqDk7WnV8P5uq4g/gyH1/WfKQYn5SgfSj4sSfw==",
       "requires": {
-        "@turf/bbox": "6.x",
-        "@turf/helpers": "6.x"
+        "@turf/bbox": "^6.3.0",
+        "@turf/helpers": "^6.3.0"
       }
     },
     "@turf/centroid": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.0.2.tgz",
-      "integrity": "sha512-auyDauOtC4eddH7GC3CHFTDu2PKhpSeKCRhwhHhXtJqn2dWCJQNIoCeJRmfXRIbzCWhWvgvQafvvhq8HNvmvWw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.3.0.tgz",
+      "integrity": "sha512-7KTyqhUEqXDoyR/nf/jAXiW8ZVszEnrp5XZkgYyrf2GWdSovSO0iCN1J3bE2jkJv7IWyeDmGYL61GGzuTSZS2Q==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/meta": "6.x"
+        "@turf/helpers": "^6.3.0",
+        "@turf/meta": "^6.3.0"
       }
     },
     "@turf/circle": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-6.0.1.tgz",
-      "integrity": "sha512-pF9XsYtCvY9ZyNqJ3hFYem9VaiGdVNQb0SFq/zzDMwH3iWZPPJQHnnDB/3e8RD1VDtBBov9p5uO2k7otsfezjw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-6.3.0.tgz",
+      "integrity": "sha512-5N3J4YQr1efidvPgvtIQYpxb7gBVEoo00IFC0JNH6KqIVBMttFZw3Wsqor34ya91m58A5m6HTiz9Cdm1ktrEdw==",
       "requires": {
-        "@turf/destination": "6.x",
-        "@turf/helpers": "6.x"
+        "@turf/destination": "^6.3.0",
+        "@turf/helpers": "^6.3.0"
       }
     },
     "@turf/clone": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.0.2.tgz",
-      "integrity": "sha512-UVpYPnW3wRj3bPncR6Z2PRbowBk+nEdVWgGewPxrKKLfvswtVtG9n/OIyvbU3E3ZOadBVxTH2uAMEMOz4800FA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.3.0.tgz",
+      "integrity": "sha512-GAgN89/9GCqUKECB1oY2hcTs0K2rZj+a2tY6VfM0ef9wwckuQZCKi+kKGUzhKVrmHee15jKV8n6DY0er8OndKg==",
       "requires": {
-        "@turf/helpers": "6.x"
+        "@turf/helpers": "^6.3.0"
       }
     },
     "@turf/concave": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-6.0.5.tgz",
-      "integrity": "sha512-Q5MFprfp/9ZjZ1xr1B30sxf1uV/IzeuJBpAcP6uowbaKkWccVwHi29Nd02cEMsVfoubk/QO2uma2PMunbbRiTg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-6.3.0.tgz",
+      "integrity": "sha512-9BPctrW2Oy9K2jjKv80tR26RQEJjwAAFwgG8JEBK8hSF9zdqa07fzx7Ncj+8hM9+3vF30f2TvQ8yxvoH7HSvXA==",
       "requires": {
-        "@turf/clone": "6.x",
-        "@turf/distance": "6.x",
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x",
-        "@turf/tin": "6.x",
+        "@turf/clone": "^6.3.0",
+        "@turf/distance": "^6.3.0",
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0",
+        "@turf/meta": "^6.3.0",
+        "@turf/tin": "^6.3.0",
         "topojson": "3.x"
       }
     },
     "@turf/destination": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-6.0.1.tgz",
-      "integrity": "sha512-MroK4nRdp7as174miCAugp8Uvorhe6rZ7MJiC9Hb4+hZR7gNFJyVKmkdDDXIoCYs6MJQsx0buI+gsCpKwgww0Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-6.3.0.tgz",
+      "integrity": "sha512-aLt3U/XkJWyZW08Ln1qZwBNAGh27yhmYLu892+dBj3gKP6UUiR6ZopXxrBwjBVe00A6k2ktftKDn79qe0hptuw==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x"
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0"
       }
     },
     "@turf/difference": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-6.0.2.tgz",
-      "integrity": "sha512-WtXkvFgOyHqsG3xtYG/m5Su+gkvyCUTbdW0XOuc3Ha2u9UeeBSGwEzTc2y9THDLDhHqR+DlTl1MMEBihXcy3fg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-6.3.0.tgz",
+      "integrity": "sha512-f4P0ra0jBOFk4HO8n/9FZ3NEmOX7FHCXHy/4Z1RSUUQsUQDCkx6/cyqbi8BCy2ZSDUSCGHV+iPgs4fRphMzCHQ==",
       "requires": {
-        "@turf/area": "6.x",
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x",
-        "martinez-polygon-clipping": "^0.4.3"
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0",
+        "polygon-clipping": "^0.15.2"
       }
     },
     "@turf/distance": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.0.1.tgz",
-      "integrity": "sha512-q7t7rWIWfkg7MP1Vt4uLjSEhe5rPfCO2JjpKmk7JC+QZKEQkuvHEqy3ejW1iC7Kw5ZcZNR3qdMGGz+6HnVwqvg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.3.0.tgz",
+      "integrity": "sha512-basi24ssNFnH3iXPFjp/aNUrukjObiFWoIyDRqKyBJxVwVOwAWvfk4d38QQyBj5nDo5IahYRq/Q+T47/5hSs9w==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x"
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0"
       }
     },
     "@turf/ellipse": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
-      "integrity": "sha1-1XyrhTmFkgzeYCKKeNgEWAJcVL4=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-6.3.0.tgz",
+      "integrity": "sha512-r+EvUK+IGgc3shvS/T1Wof2uCptS2fYmtcwMSFHnHjRnmUyrD4YFjPZT7ygxcDB91+UClZ6cdozR6vqBYzPAog==",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/transform-rotate": "^5.1.5"
-      },
-      "dependencies": {
-        "@turf/helpers": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
-        },
-        "@turf/invariant": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
-          "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        }
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0",
+        "@turf/rhumb-destination": "^6.3.0",
+        "@turf/transform-rotate": "^6.3.0"
       }
     },
     "@turf/helpers": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-      "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
+      "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
     },
     "@turf/intersect": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-6.1.3.tgz",
-      "integrity": "sha512-SeAJG/zPRRTeyK2OifkPoyLq60q8tv8prpPIH3R8ZhyF4MdLOnMv5MURaQ6kQd+3UTDrL+pYm6rqbPvln1zqIw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-6.3.0.tgz",
+      "integrity": "sha512-1YCIkyKjuTlX7HaTjtyE7ZRxLCmcu0BYr6jqoVl7TjyF2NUiNpPm3m4X1ZrSF6MfjIt5NFSGYCdNMEPgREq19w==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "martinez-polygon-clipping": "^0.4.3"
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0",
+        "polygon-clipping": "^0.15.2"
       }
     },
     "@turf/invariant": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
-      "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.3.0.tgz",
+      "integrity": "sha512-2OFOi9p+QOrcIMySEnr+WlOiKaFZ1bY56jA98YyECewJHfhPFWUBZEhc4nWGRT0ahK08Vus9+gcuBX8QIpCIIw==",
       "requires": {
-        "@turf/helpers": "6.x"
+        "@turf/helpers": "^6.3.0"
       }
     },
     "@turf/line-intersect": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.0.2.tgz",
-      "integrity": "sha512-pfL/lBu7ukBPdTjvSCmcNUzZ83V4R95htwqs5NqU8zeS4R+5KTwacbrOYKztjpmHBwUmPEIIpSbqkUoD0Fp7kg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.3.0.tgz",
+      "integrity": "sha512-3naxR7XpkPd2vst3Mw6DFry4C9m3o0/f2n/xu5UAyxb88Ie4m2k+1eqkhzMMx/0L+E6iThWpLx7DASM6q6o9ow==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/line-segment": "6.x",
-        "@turf/meta": "6.x",
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0",
+        "@turf/line-segment": "^6.3.0",
+        "@turf/meta": "^6.3.0",
         "geojson-rbush": "3.x"
       }
     },
     "@turf/line-overlap": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-6.0.2.tgz",
-      "integrity": "sha512-Y7VTttNM+31R2hPa9N4a9ZaX/n1eOHvJkeBivXr/LBZClba365IzD9vtljYHMZQqD3SN7VmFJSmJyBIghO4V3Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-6.3.0.tgz",
+      "integrity": "sha512-fVyXfTpr/A+ZXZWG6PbuYz5rAGbTQWyrMZveCl2049SbOXSkVXGjUfpnLaklP0p+adw7eRR0LhZn6FGz9CQaFg==",
       "requires": {
-        "@turf/boolean-point-on-line": "6.x",
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/line-segment": "6.x",
-        "@turf/meta": "6.x",
-        "@turf/nearest-point-on-line": "6.x",
+        "@turf/boolean-point-on-line": "^6.3.0",
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0",
+        "@turf/line-segment": "^6.3.0",
+        "@turf/meta": "^6.3.0",
+        "@turf/nearest-point-on-line": "^6.3.0",
         "deep-equal": "1.x",
         "geojson-rbush": "3.x"
       }
     },
     "@turf/line-segment": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.0.2.tgz",
-      "integrity": "sha512-8AkzDHoNw3X68y115josal+lvdAi4b2P1K0YNTKGyLRBaUhPXVSuMBpMd53FRF1hYEb9UJgMbugF9ZE7m5L6zg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.3.0.tgz",
+      "integrity": "sha512-M+aDy83V+E7jYWNaf+b+A88yhnMrJhyg/lhAj6mU6UeB2PbruXB2qgSmmVDSE2dIknOvZZuIWNzEzUI07RO2kw==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x"
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0",
+        "@turf/meta": "^6.3.0"
       }
     },
     "@turf/meta": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
-      "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.3.0.tgz",
+      "integrity": "sha512-qBJjaAJS9H3ap0HlGXyF/Bzfl0qkA9suafX/jnDsZvWMfVLt+s+o6twKrXOGk5t7nnNON2NFRC8+czxpu104EQ==",
       "requires": {
-        "@turf/helpers": "6.x"
+        "@turf/helpers": "^6.3.0"
       }
     },
     "@turf/nearest-point-on-line": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-6.0.2.tgz",
-      "integrity": "sha512-re9tSEwYyG1EMo4ObXXAKYVhkMVANPIIJQ1V/J1lKcNfHVc1pYmd3D5jkTNBh+oriI9VL4PVML3eqYE+Zcg0mg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-6.3.0.tgz",
+      "integrity": "sha512-b4C9Md1VbGn9chMgdSj2grJD4w4t0owEWOKEBwOZfdhrcksyOedVvKB7XqOFdj/8Jitel40EKAC5LQTNu24kEQ==",
       "requires": {
-        "@turf/bearing": "6.x",
-        "@turf/destination": "6.x",
-        "@turf/distance": "6.x",
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/line-intersect": "6.x",
-        "@turf/meta": "6.x"
+        "@turf/bearing": "^6.3.0",
+        "@turf/destination": "^6.3.0",
+        "@turf/distance": "^6.3.0",
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0",
+        "@turf/line-intersect": "^6.3.0",
+        "@turf/meta": "^6.3.0"
       }
     },
     "@turf/point-to-line-distance": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-6.0.0.tgz",
-      "integrity": "sha512-2UuZFtn8MRfrqBHSqkrH/jm5q/VedyL7a4YC50Nd5FqXs5TgmAB7ms2igSbCkyaOtRypGhMl9fun3Hg5PIVRMQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-6.3.0.tgz",
+      "integrity": "sha512-AqCcj4A0GPzKb3w+q+C9ex0r5mC+u+Ee6VN2jY1p25dxBQJNpMZKDE5LcWtaXeD+pAk3ZGmvea8LR5S0AJukxA==",
       "requires": {
-        "@turf/bearing": "6.x",
-        "@turf/distance": "6.x",
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x",
-        "@turf/projection": "6.x",
-        "@turf/rhumb-bearing": "6.x",
-        "@turf/rhumb-distance": "6.x"
-      },
-      "dependencies": {
-        "@turf/projection": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.0.1.tgz",
-          "integrity": "sha512-Y3RvGT6I53MjYKLG69e9sMk45wJXcLbrEO1t6P3WQQQGqA2gYhhMJyV41vE2Z2llrJpvs2dDx/tIeQzGd0HHMQ==",
-          "requires": {
-            "@turf/clone": "6.x",
-            "@turf/helpers": "6.x",
-            "@turf/meta": "6.x"
-          }
-        },
-        "@turf/rhumb-bearing": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.0.1.tgz",
-          "integrity": "sha512-MVBra8OVfjM4+/N0B3o6cBIYg9p/uRKzA9uk05RfrzasEbUL1vdD23LkTooVL74Yw4UxL8BQD9hS5Re2COJFDA==",
-          "requires": {
-            "@turf/helpers": "6.x",
-            "@turf/invariant": "6.x"
-          }
-        },
-        "@turf/rhumb-distance": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.0.1.tgz",
-          "integrity": "sha512-3G45DQtQByzzfHFPcCyJdUZFwsd45zfZ7sAb1ddF7mhEj4G70+T2G3GKjInymqDNrbyh2gbG6wQiZSToC8Uf9g==",
-          "requires": {
-            "@turf/helpers": "6.x",
-            "@turf/invariant": "6.x"
-          }
-        }
+        "@turf/bearing": "^6.3.0",
+        "@turf/distance": "^6.3.0",
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0",
+        "@turf/meta": "^6.3.0",
+        "@turf/projection": "^6.3.0",
+        "@turf/rhumb-bearing": "^6.3.0",
+        "@turf/rhumb-distance": "^6.3.0"
       }
     },
     "@turf/polygon-to-line": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-6.0.3.tgz",
-      "integrity": "sha512-cJUy7VYLAhgnTBOtYFjNzh5bSlAS/qM8gUHXRGrIxI22RUJk4FXs/X2MEJ4Ki2flCiSeOjRIUEawEslNe7w7RA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-6.3.0.tgz",
+      "integrity": "sha512-KFGlQlGOBayBvELz+tip1zCa3eB8xyZePZUZ3I3OnU7mk0FFzJzvLTmPUc7MupgqORT4LkNGmyKSVWaz38NTig==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x"
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0"
       }
     },
     "@turf/projection": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
-      "integrity": "sha1-JFF+7rLzaBa6n3EueubWo2jt91c=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.3.0.tgz",
+      "integrity": "sha512-IpSs7Q6G6xi47ynVlYYVegPLy6Jc0yo3/DcIm83jaJa4NnzPFXIFZT0v9Fe1N8MraHZqiqaSPbVnJXCGwR12lg==",
       "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      },
-      "dependencies": {
-        "@turf/clone": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
-          "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/helpers": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
-        },
-        "@turf/meta": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
-          "integrity": "sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        }
+        "@turf/clone": "^6.3.0",
+        "@turf/helpers": "^6.3.0",
+        "@turf/meta": "^6.3.0"
       }
     },
     "@turf/rewind": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
-      "integrity": "sha1-nqPbSmi3PB/R3RH1djGxQ8/vock=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-6.3.0.tgz",
+      "integrity": "sha512-56HwvOZ4r4/wXr8l8zCpdjZ3bxY6Ee7aokuJr/+BlVqikHdRHRx+FJpLGpykZU1YWdO7IiLK7ajX+clYPaqRKg==",
       "requires": {
-        "@turf/boolean-clockwise": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
-      },
-      "dependencies": {
-        "@turf/clone": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
-          "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/helpers": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
-        },
-        "@turf/invariant": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
-          "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/meta": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
-          "integrity": "sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        }
+        "@turf/boolean-clockwise": "^6.3.0",
+        "@turf/clone": "^6.3.0",
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0",
+        "@turf/meta": "^6.3.0"
       }
     },
     "@turf/rhumb-bearing": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
-      "integrity": "sha1-rPalAkJ+uMSeGM2mrg7/qwxd3NI=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.3.0.tgz",
+      "integrity": "sha512-/c/BE3huEUrwN6gx7Bg2FzfJqeU+TWk/slQPDHpbVunlIPbS6L28brqSVD+KXfMG8HQIzynz6Pm4Y+j5Iv4aWA==",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      },
-      "dependencies": {
-        "@turf/helpers": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
-        },
-        "@turf/invariant": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
-          "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        }
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0"
       }
     },
     "@turf/rhumb-destination": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
-      "integrity": "sha1-sbKuuSFUfyrAwamUtqEw+SRjx0I=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-6.3.0.tgz",
+      "integrity": "sha512-MaQf5wldfERfn8cjtbkD/6GUurAwD+sjedvDgV/chZ83yx7kXmRgrVMpRSGUbmGQ3Ww8dn38sUCapnM6M07+Rg==",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      },
-      "dependencies": {
-        "@turf/helpers": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
-        },
-        "@turf/invariant": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
-          "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        }
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0"
       }
     },
     "@turf/rhumb-distance": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
-      "integrity": "sha1-GAaFdiX0IlOE2tQT5p85U4/192U=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.3.0.tgz",
+      "integrity": "sha512-wMIQVvznusonnp/POeucFdA4Rubn0NrkcEMdxdcCgFK7OmTz0zU4CEnNONF2IUGkQ5WwoKiuS7MOTQ8OuCjSfQ==",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
-      },
-      "dependencies": {
-        "@turf/helpers": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
-        },
-        "@turf/invariant": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
-          "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        }
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0"
       }
     },
     "@turf/tin": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-6.0.2.tgz",
-      "integrity": "sha512-J0YnAPBY+O4x627Pv06cVjFrSDEaVMkbzXFY9cw+bPcE8PExCbC0ZOodW7ZLRiqAUgR4+ofTjrrWY5ZrshQLdw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-6.3.0.tgz",
+      "integrity": "sha512-obk9vyzKo3o3Dy4fPlb8IROb9LdMlz4LvKZ63DNtQsxwrWsc+og0EOh2mpvZrCIeoObx3ah5SnuAh14xH4JybA==",
       "requires": {
-        "@turf/helpers": "6.x"
+        "@turf/helpers": "^6.3.0"
       }
     },
     "@turf/transform-rotate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
-      "integrity": "sha1-0Jbt2eMA/jFQadVNjkWMQJIh7fs=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-6.3.0.tgz",
+      "integrity": "sha512-6CPfmDdaXjbBoPeyHkui704vz6MD3MoI09LGRVJ/RIo1uH/OL6RDSlCfLxFtkE33FJ7VV4giczc3LF1UP5Oh9w==",
       "requires": {
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/rhumb-distance": "^5.1.5"
-      },
-      "dependencies": {
-        "@turf/centroid": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
-          "integrity": "sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/clone": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
-          "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/helpers": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
-        },
-        "@turf/invariant": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
-          "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/meta": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
-          "integrity": "sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        }
+        "@turf/centroid": "^6.3.0",
+        "@turf/clone": "^6.3.0",
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0",
+        "@turf/meta": "^6.3.0",
+        "@turf/rhumb-bearing": "^6.3.0",
+        "@turf/rhumb-destination": "^6.3.0",
+        "@turf/rhumb-distance": "^6.3.0"
       }
     },
     "@turf/transform-scale": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
-      "integrity": "sha1-cP064BhWz3uunxWtVhzf6PiQAbk=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-6.3.0.tgz",
+      "integrity": "sha512-UnLWEXAUdZy7JYbylMjYczPUkxXlUK1nMgv7zEzQ+8mczysPVsgB/FDyiexY2bgVEEBMeDqFSHtqLRavXljI0A==",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/rhumb-distance": "^5.1.5"
-      },
-      "dependencies": {
-        "@turf/bbox": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
-          "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/center": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
-          "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
-          "requires": {
-            "@turf/bbox": "^5.1.5",
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/centroid": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
-          "integrity": "sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=",
-          "requires": {
-            "@turf/helpers": "^5.1.5",
-            "@turf/meta": "^5.1.5"
-          }
-        },
-        "@turf/clone": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
-          "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/helpers": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
-        },
-        "@turf/invariant": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
-          "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/meta": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
-          "integrity": "sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        }
+        "@turf/bbox": "^6.3.0",
+        "@turf/center": "^6.3.0",
+        "@turf/centroid": "^6.3.0",
+        "@turf/clone": "^6.3.0",
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0",
+        "@turf/meta": "^6.3.0",
+        "@turf/rhumb-bearing": "^6.3.0",
+        "@turf/rhumb-destination": "^6.3.0",
+        "@turf/rhumb-distance": "^6.3.0"
       }
     },
     "@turf/transform-translate": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
-      "integrity": "sha1-Uwolf7Hccmja3Ks05nkB6yo97GM=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-6.3.0.tgz",
+      "integrity": "sha512-ZGAK3T6wdYLOIKr/FHl+i09b1vhPV3XWHw4/M27xA6US2rNcO6/jkLjskdME/3JzJDFmGa8F2vlPqlhtWWoRSw==",
       "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5"
-      },
-      "dependencies": {
-        "@turf/clone": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
-          "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/helpers": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
-        },
-        "@turf/invariant": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
-          "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        },
-        "@turf/meta": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
-          "integrity": "sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=",
-          "requires": {
-            "@turf/helpers": "^5.1.5"
-          }
-        }
+        "@turf/clone": "^6.3.0",
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0",
+        "@turf/meta": "^6.3.0",
+        "@turf/rhumb-destination": "^6.3.0"
       }
     },
     "@turf/union": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@turf/union/-/union-6.0.3.tgz",
-      "integrity": "sha512-SJPhEvsR96k4vFqymxPPC43jcqFydTafGjHWnYzlupxqUDzIYD8X5d9Ed8mONl2T9oM4ErbNuuZ9j/eHvoWtKw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-6.3.0.tgz",
+      "integrity": "sha512-m8yh13Q5E0Y+YC10+iI/Qq0Txt7UmSIFByc7DfNVlMMGTceqLFa8xGwSVdFuB/d6MWwKuzKonQMl1PUx/Vd2Iw==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "martinez-polygon-clipping": "^0.4.3"
+        "@turf/helpers": "^6.3.0",
+        "@turf/invariant": "^6.3.0",
+        "polygon-clipping": "^0.15.2"
       }
     },
     "@types/backbone": {
@@ -2806,9 +2480,9 @@
       "integrity": "sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ=="
     },
     "@types/hammerjs": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.36.tgz",
-      "integrity": "sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ=="
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.38.tgz",
+      "integrity": "sha512-wuwDzWW1JWh3BZoRftBlKcctjNzR75QFY4/b4zAz7sH1EesA8HBJzke+bF5dxCATNdHHs3X1P5UWanbbUT6chw=="
     },
     "@types/jquery": {
       "version": "3.5.1",
@@ -2841,18 +2515,18 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.0.tgz",
-      "integrity": "sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
-          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
         }
       }
     },
@@ -3598,9 +3272,9 @@
       }
     },
     "broadcast-channel": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.3.0.tgz",
-      "integrity": "sha512-mi0xKJxdHHMb/PqIGLybPlAHMqs/ShxXSylaVYVM20ViizXEbjaXAy9Q6YalUGX5FoAls0UBNaT8mX8LR259bA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.4.1.tgz",
+      "integrity": "sha512-VXYivSkuBeQY+pL5hNQQNvBdKKQINBAROm4G8lAbWQfOZ7Yn4TMcgLNlJyEqlkxy5G8JJBsI3VJ1u8FUTOROcg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
         "detect-node": "^2.0.4",
@@ -3825,12 +3499,12 @@
       }
     },
     "call-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
-      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "requires": {
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.0"
+        "get-intrinsic": "^1.0.2"
       }
     },
     "call-me-maybe": {
@@ -4084,6 +3758,11 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
+    },
+    "complex.js": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.11.tgz",
+      "integrity": "sha512-6IArJLApNtdg1P1dFtn3dnyzoZBEF0MwMnrfF1exSBRpZYoy4yieMkpZhQDC0uwctw48vii0CFVyHfpgZ/DfGw=="
     },
     "component-classes": {
       "version": "1.2.6",
@@ -4409,9 +4088,12 @@
       "dev": true
     },
     "d3-array": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.9.1.tgz",
-      "integrity": "sha512-Ob7RdOtkqsjx1NWyQHMFLtCSk6/aKTxDdC4ZIolX+O+mDD2RzrsYgAyc0WGAlfYFVELLSilS7w8BtE3PKM8bHg=="
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.11.0.tgz",
+      "integrity": "sha512-26clcwmHQEdsLv34oNKq5Ia9tQ26Y/4HqS3dQzF42QBUqymZJ+9PORcN1G52bt37NsL2ABoX4lvyYZc+A9Y0zw==",
+      "requires": {
+        "internmap": "^1.0.0"
+      }
     },
     "d3-axis": {
       "version": "1.0.12",
@@ -4701,6 +4383,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decimal.js": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
+    },
     "deck.gl": {
       "version": "8.4.0-alpha.4",
       "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-8.4.0-alpha.4.tgz",
@@ -4717,6 +4404,42 @@
         "@deck.gl/mapbox": "8.4.0-alpha.4",
         "@deck.gl/mesh-layers": "8.4.0-alpha.4",
         "@deck.gl/react": "8.4.0-alpha.4"
+      },
+      "dependencies": {
+        "@deck.gl/geo-layers": {
+          "version": "8.4.0-alpha.4",
+          "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.4.0-alpha.4.tgz",
+          "integrity": "sha512-CE0SdpibxjaQcVljxT1iZOJKY66acJro3pfDhVGIg4o7A8enGHIIkK9Pk1FnmNbATvFkWHGzet5T3yKFleuwMw==",
+          "requires": {
+            "@loaders.gl/3d-tiles": "^2.3.0",
+            "@loaders.gl/loader-utils": "^2.3.0",
+            "@loaders.gl/mvt": "^2.3.0",
+            "@loaders.gl/terrain": "^2.3.0",
+            "@loaders.gl/tiles": "^2.3.0",
+            "@math.gl/culling": "^3.3.2",
+            "@math.gl/web-mercator": "^3.3.2",
+            "h3-js": "^3.6.0",
+            "long": "^3.2.0",
+            "math.gl": "^3.3.2"
+          }
+        },
+        "@deck.gl/mesh-layers": {
+          "version": "8.4.0-alpha.4",
+          "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.4.0-alpha.4.tgz",
+          "integrity": "sha512-QX0fN/VtjARuvsLmwgw+ANYAX2RKUXGIKIpwaRSv89YSgvZWnQqlrisUEw65K6yxB2Ms4SUnvk5f39co0ZD2Qg==",
+          "requires": {
+            "@luma.gl/experimental": "^8.3.1",
+            "@luma.gl/shadertools": "^8.3.1"
+          }
+        },
+        "@deck.gl/react": {
+          "version": "8.4.0-alpha.4",
+          "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.4.0-alpha.4.tgz",
+          "integrity": "sha512-u7r1MXnexp52HdOepmZSNEN+41xl6kW2Hpz5XfDs/IhuhNx/TTFkxzOx6h/c2iAg+1VprxZsz4R8NMaARYxX8g==",
+          "requires": {
+            "prop-types": "^15.6.0"
+          }
+        }
       }
     },
     "decode-uri-component": {
@@ -4884,9 +4607,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
-          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
         }
       }
     },
@@ -5051,19 +4774,32 @@
       }
     },
     "enzyme-adapter-react-16": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.5.tgz",
-      "integrity": "sha512-33yUJGT1nHFQlbVI5qdo5Pfqvu/h4qPwi1o0a6ZZsjpiqq92a3HjynDhwd1IeED+Su60HDWV8mxJqkTnLYdGkw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.6.tgz",
+      "integrity": "sha512-yFlVJCXh8T+mcQo8M6my9sPgeGzj85HSHi6Apgf1Cvq/7EL/J9+1JoJmJsRxZgyTvPMAqOEpRSu/Ii/ZpyOk0g==",
       "requires": {
-        "enzyme-adapter-utils": "^1.13.1",
+        "enzyme-adapter-utils": "^1.14.0",
         "enzyme-shallow-equal": "^1.0.4",
         "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "object.values": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "object.values": "^1.1.2",
         "prop-types": "^15.7.2",
         "react-is": "^16.13.1",
         "react-test-renderer": "^16.0.0-0",
         "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "enzyme-adapter-utils": {
@@ -5138,6 +4874,11 @@
         "string.prototype.trimstart": "^1.0.1"
       },
       "dependencies": {
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+        },
         "object.assign": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
@@ -5165,6 +4906,11 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
       "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ=="
+    },
+    "escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -5496,9 +5242,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-xml-parser": {
-      "version": "3.17.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.6.tgz",
-      "integrity": "sha512-40WHI/5d2MOzf1sD2bSaTXlPn1lueJLAX6j1xH5dSAr6tNeut8B9ktEL6sjAK9yVON4uNj9//axOdBJUuruCzw=="
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.18.0.tgz",
+      "integrity": "sha512-tRrwShhppv0K5GKEtuVs92W0VGDaVltZAwtHbpjNF+JOT7cjIFySBGTEOmdBslXYyWYaZwEX/g4Su8ZeKg0LKQ=="
     },
     "fastparse": {
       "version": "1.1.2",
@@ -5648,6 +5394,11 @@
         }
       }
     },
+    "fraction.js": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.13.tgz",
+      "integrity": "sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA=="
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -5717,23 +5468,30 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "version": "1.18.0-next.2",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
+          "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
           "requires": {
+            "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
             "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
+            "is-negative-zero": "^2.0.1",
             "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
+            "object-inspect": "^1.9.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.3",
+            "string.prototype.trimstart": "^1.0.3"
           }
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
         },
         "object.assign": {
           "version": "4.1.2",
@@ -5794,8 +5552,8 @@
       "integrity": "sha1-kQQGSbetObKQRkO9mtUeXobVJOM="
     },
     "geotiff": {
-      "version": "github:ilan-gold/geotiff.js#90e02b8f21a4edcaec2ea3f9d1098aec0da31caa",
-      "from": "github:ilan-gold/geotiff.js#ilan-gold/viv_release_080",
+      "version": "github:ilan-gold/geotiff.js#aca49d4e406ee428c5296b8fe6ed15725f77bd0c",
+      "from": "github:ilan-gold/geotiff.js#ilan-gold/viv_083",
       "requires": {
         "lzw-tiff-decoder": "^0.1.0",
         "pako": "^1.0.11",
@@ -5809,9 +5567,9 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
-      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -6625,6 +6383,11 @@
         }
       }
     },
+    "internmap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.0.tgz",
+      "integrity": "sha512-SdoDWwNOTE2n4JWUsLn4KXZGuZPjPF9yyOGc8bnfWnBQh7BD/l80rzSznKc/r4Y0aQ7z3RTk9X+tV4tHBpu+dA=="
+    },
     "interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
@@ -6682,9 +6445,9 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -6788,10 +6551,11 @@
       }
     },
     "is-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
       "requires": {
+        "call-bind": "^1.0.2",
         "has-symbols": "^1.0.1"
       }
     },
@@ -6837,6 +6601,11 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
     },
     "jquery": {
       "version": "3.5.1",
@@ -6908,9 +6677,9 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "jss": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.0.tgz",
-      "integrity": "sha512-B6151NvG+thUg3murLNHRPLxTLwQ13ep4SH5brj4d8qKtogOx/jupnpfkPGSHPqvcwKJaCLctpj2lEk+5yGwMw==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.1.tgz",
+      "integrity": "sha512-hbbO3+FOTqVdd7ZUoTiwpHzKXIo5vGpMNbuXH1a0wubRSWLWSBvwvaq4CiHH/U42CmjOnp6lVNNs/l+Z7ZdDmg==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "csstype": "^3.0.2",
@@ -6920,77 +6689,77 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
-          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
         }
       }
     },
     "jss-plugin-camel-case": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.5.0.tgz",
-      "integrity": "sha512-GSjPL0adGAkuoqeYiXTgO7PlIrmjv5v8lA6TTBdfxbNYpxADOdGKJgIEkffhlyuIZHlPuuiFYTwUreLUmSn7rg==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.5.1.tgz",
+      "integrity": "sha512-9+oymA7wPtswm+zxVti1qiowC5q7bRdCJNORtns2JUj/QHp2QPXYwSNRD8+D2Cy3/CEMtdJzlNnt5aXmpS6NAg==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "hyphenate-style-name": "^1.0.3",
-        "jss": "10.5.0"
+        "jss": "10.5.1"
       }
     },
     "jss-plugin-default-unit": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.5.0.tgz",
-      "integrity": "sha512-rsbTtZGCMrbcb9beiDd+TwL991NGmsAgVYH0hATrYJtue9e+LH/Gn4yFD1ENwE+3JzF3A+rPnM2JuD9L/SIIWw==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.5.1.tgz",
+      "integrity": "sha512-D48hJBc9Tj3PusvlillHW8Fz0y/QqA7MNmTYDQaSB/7mTrCZjt7AVRROExoOHEtd2qIYKOYJW3Jc2agnvsXRlQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.5.0"
+        "jss": "10.5.1"
       }
     },
     "jss-plugin-global": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.5.0.tgz",
-      "integrity": "sha512-FZd9+JE/3D7HMefEG54fEC0XiQ9rhGtDHAT/ols24y8sKQ1D5KIw6OyXEmIdKFmACgxZV2ARQ5pAUypxkk2IFQ==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.5.1.tgz",
+      "integrity": "sha512-jX4XpNgoaB8yPWw/gA1aPXJEoX0LNpvsROPvxlnYe+SE0JOhuvF7mA6dCkgpXBxfTWKJsno7cDSCgzHTocRjCQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.5.0"
+        "jss": "10.5.1"
       }
     },
     "jss-plugin-nested": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.5.0.tgz",
-      "integrity": "sha512-ejPlCLNlEGgx8jmMiDk/zarsCZk+DV0YqXfddpgzbO9Toamo0HweCFuwJ3ZO40UFOfqKwfpKMVH/3HUXgxkTMg==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.5.1.tgz",
+      "integrity": "sha512-xXkWKOCljuwHNjSYcXrCxBnjd8eJp90KVFW1rlhvKKRXnEKVD6vdKXYezk2a89uKAHckSvBvBoDGsfZrldWqqQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.5.0",
+        "jss": "10.5.1",
         "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-props-sort": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.5.0.tgz",
-      "integrity": "sha512-kTLRvrOetFKz5vM88FAhLNeJIxfjhCepnvq65G7xsAQ/Wgy7HwO1BS/2wE5mx8iLaAWC6Rj5h16mhMk9sKdZxg==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.5.1.tgz",
+      "integrity": "sha512-t+2vcevNmMg4U/jAuxlfjKt46D/jHzCPEjsjLRj/J56CvP7Iy03scsUP58Iw8mVnaV36xAUZH2CmAmAdo8994g==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.5.0"
+        "jss": "10.5.1"
       }
     },
     "jss-plugin-rule-value-function": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.5.0.tgz",
-      "integrity": "sha512-jXINGr8BSsB13JVuK274oEtk0LoooYSJqTBCGeBu2cG/VJ3+4FPs1gwLgsq24xTgKshtZ+WEQMVL34OprLidRA==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.5.1.tgz",
+      "integrity": "sha512-3gjrSxsy4ka/lGQsTDY8oYYtkt2esBvQiceGBB4PykXxHoGRz14tbCK31Zc6DHEnIeqsjMUGbq+wEly5UViStQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.5.0",
+        "jss": "10.5.1",
         "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-vendor-prefixer": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.5.0.tgz",
-      "integrity": "sha512-rux3gmfwDdOKCLDx0IQjTwTm03IfBa+Rm/hs747cOw5Q7O3RaTUIMPKjtVfc31Xr/XI9Abz2XEupk1/oMQ7zRA==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.5.1.tgz",
+      "integrity": "sha512-cLkH6RaPZWHa1TqSfd2vszNNgxT1W0omlSjAd6hCFHp3KIocSrW21gaHjlMU26JpTHwkc+tJTCQOmE/O1A4FKQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "css-vendor": "^2.0.8",
-        "jss": "10.5.0"
+        "jss": "10.5.1"
       }
     },
     "keycode": {
@@ -7189,26 +6958,32 @@
         "object-visit": "^1.0.0"
       }
     },
-    "martinez-polygon-clipping": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.4.3.tgz",
-      "integrity": "sha512-3ZNS0ksKhWTLsmCUkNf+/UimndZ5U2cVOS0I+IjiwF+M23E77TmeOZSmbRJbfCoQUog/vcQ42s3DXrhgOhgPqw==",
-      "requires": {
-        "splaytree": "^0.1.4",
-        "tinyqueue": "^1.2.0"
-      }
-    },
     "material-colors": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "math.gl": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/math.gl/-/math.gl-3.4.1.tgz",
-      "integrity": "sha512-D33ZXryVFcHu1YJ+fgcNp2MkyK+mEfHesHMdQUZBz2hFqIsAwXovM1sJ+0rTcs8IyTFmuRJ2ayHf1igEJEOM2g==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/math.gl/-/math.gl-3.4.2.tgz",
+      "integrity": "sha512-0I77HBiC+q/XRRw807dCwUeMTUotzNQUQZEk0kPd39iRmU67dLId0+OtCGFYjIzyM+gNaj1JWueiOYV/gdl+dQ==",
       "requires": {
-        "@math.gl/core": "3.4.1"
+        "@math.gl/core": "3.4.2"
+      }
+    },
+    "mathjs": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-9.2.0.tgz",
+      "integrity": "sha512-R2fQxaOmyifxgP4+c59dnfLwpKI1KYHdnT5lLwDuHIZvgyGb71M8ay6kTJTEv9rG04pduqvX4tbBUoG5ypTF8A==",
+      "requires": {
+        "complex.js": "^2.0.11",
+        "decimal.js": "^10.2.1",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^4.0.13",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^2.0.0"
       }
     },
     "md5.js": {
@@ -7648,9 +7423,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
+      "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w="
     },
     "object-is": {
       "version": "1.1.4",
@@ -7698,23 +7473,30 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "version": "1.18.0-next.2",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
+          "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
           "requires": {
+            "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
             "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
+            "is-negative-zero": "^2.0.1",
             "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
+            "object-inspect": "^1.9.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.3",
+            "string.prototype.trimstart": "^1.0.3"
           }
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
         },
         "object.assign": {
           "version": "4.1.2",
@@ -7741,23 +7523,30 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "version": "1.18.0-next.2",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
+          "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
           "requires": {
+            "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
             "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
+            "is-negative-zero": "^2.0.1",
             "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
+            "object-inspect": "^1.9.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.3",
+            "string.prototype.trimstart": "^1.0.3"
           }
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
         },
         "object.assign": {
           "version": "4.1.2",
@@ -7793,23 +7582,30 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "version": "1.18.0-next.2",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
+          "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
           "requires": {
+            "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
             "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
+            "is-negative-zero": "^2.0.1",
             "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
+            "object-inspect": "^1.9.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.3",
+            "string.prototype.trimstart": "^1.0.3"
           }
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
         },
         "object.assign": {
           "version": "4.1.2",
@@ -8173,6 +7969,14 @@
         "ts-pnp": "^1.1.6"
       }
     },
+    "polygon-clipping": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/polygon-clipping/-/polygon-clipping-0.15.2.tgz",
+      "integrity": "sha512-qsUFQSY4nA++1/b76dy0BJGwL0FZAk05Y4hZprctLIhAddE8KUUr3TxIF4sAxIQtjH9xvaBe3raaRQrcSI4wlA==",
+      "requires": {
+        "splaytree": "^3.1.0"
+      }
+    },
     "popper.js": {
       "version": "1.16.1-lts",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
@@ -8346,9 +8150,9 @@
       }
     },
     "protocol-buffers-schema": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
-      "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.5.1.tgz",
+      "integrity": "sha512-YVCvdhxWNDP8/nJDyXLuM+UFsuPk4+1PB7WGPVDzm3HTHbzFLxQYeW2iZpS4mmnXrQJGBzt230t/BbEb7PrQaw=="
     },
     "prr": {
       "version": "1.0.1",
@@ -8662,12 +8466,23 @@
       }
     },
     "rc-util": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.6.5.tgz",
-      "integrity": "sha512-WwgwI80qxs+LJkxERKLbjLF4LuBoyH1KSQVphF3P0JPFxrJkiXHPF6hbJy51oHceXmqh1wizVwdNGF1DsSDZmA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.8.0.tgz",
+      "integrity": "sha512-x8UGbURS1/9mMyqNMsRdCq+nBLefjcubfS++d/P/oAKZ2b0X2Zo6TPPPS4nKyZIK8Xvo4DFx5zfwJ9hUm9CRYQ==",
       "requires": {
+        "@babel/runtime": "^7.12.5",
         "react-is": "^16.12.0",
         "shallowequal": "^1.1.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
+          "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "react": {
@@ -9161,18 +8976,18 @@
       },
       "dependencies": {
         "@types/react": {
-          "version": "16.14.2",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.2.tgz",
-          "integrity": "sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==",
+          "version": "16.14.4",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.4.tgz",
+          "integrity": "sha512-ETj7GbkPGjca/A4trkVeGvoIakmLV6ZtX3J8dcmOpzKzWVybbrOxanwaIPG71GZwImoMDY6Fq4wIe34lEqZ0FQ==",
           "requires": {
             "@types/prop-types": "*",
             "csstype": "^3.0.2"
           }
         },
         "csstype": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
-          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
         }
       }
     },
@@ -9274,12 +9089,12 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
-      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       }
     },
     "regexpu-core": {
@@ -9583,6 +9398,11 @@
         "ajv-keywords": "^3.5.2"
       }
     },
+    "seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    },
     "select": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
@@ -9862,9 +9682,9 @@
       "dev": true
     },
     "splaytree": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
-      "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.1.0.tgz",
+      "integrity": "sha512-gvUGR7xnOy0fLKTCxDeUZYgU/I1Tdf8M/lM1Qrf8L2TIOR5ipZjGk02uYcdv0o2x7WjVRgpm3iS2clLyuVAt0Q=="
     },
     "split-string": {
       "version": "3.1.0",
@@ -9966,11 +9786,6 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "object-inspect": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
-          "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w="
         },
         "object-keys": {
           "version": "0.4.0",
@@ -10317,8 +10132,7 @@
     "tiny-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "optional": true
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tiny-warning": {
       "version": "1.0.3",
@@ -10338,11 +10152,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
       "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
-    },
-    "tinyqueue": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
-      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
     },
     "tmp": {
       "version": "0.0.33",
@@ -10499,6 +10308,11 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
       "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
       "dev": true
+    },
+    "typed-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.0.0.tgz",
+      "integrity": "sha512-Hhy1Iwo/e4AtLZNK10ewVVcP2UEs408DS35ubP825w/YgSBK1KVLwALvvIG4yX75QJrxjCpcWkzkVRB0BwwYlA=="
     },
     "typedarray": {
       "version": "0.0.6",
@@ -10771,9 +10585,9 @@
       "dev": true
     },
     "vega": {
-      "version": "5.17.3",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.17.3.tgz",
-      "integrity": "sha512-c8N2pNg9MMmC6shNpoxVw3aVp2XPFOgmWNX5BEOAdCaGHRnSgzNy44+gYdGRaIe6+ljTzZg99Mf+OLO50IP42A==",
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.19.1.tgz",
+      "integrity": "sha512-UE6/c9q9kzuz4HULFuU9HscBASoZa+zcXqGKdbQP545Nwmhd078QpcH+wZsq9lYfiTxmFtzLK/a0OH0zhkghvA==",
       "requires": {
         "vega-crossfilter": "~4.0.5",
         "vega-dataflow": "~5.7.3",
@@ -10782,17 +10596,17 @@
         "vega-expression": "~4.0.1",
         "vega-force": "~4.0.7",
         "vega-format": "~1.0.4",
-        "vega-functions": "~5.10.0",
+        "vega-functions": "~5.12.0",
         "vega-geo": "~4.3.8",
         "vega-hierarchy": "~4.0.9",
         "vega-label": "~1.0.0",
         "vega-loader": "~4.4.0",
-        "vega-parser": "~6.1.2",
+        "vega-parser": "~6.1.3",
         "vega-projection": "~1.4.5",
         "vega-regression": "~1.0.9",
         "vega-runtime": "~6.1.3",
         "vega-scale": "~7.1.1",
-        "vega-scenegraph": "~4.9.2",
+        "vega-scenegraph": "~4.9.3",
         "vega-statistics": "~1.7.9",
         "vega-time": "~2.0.4",
         "vega-transforms": "~4.9.3",
@@ -10830,16 +10644,16 @@
       }
     },
     "vega-embed": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.15.0.tgz",
-      "integrity": "sha512-/+Xlf0D4ErI21R20ElkP0ZP+qFHJoLsnbBGidJSYmnUGn5mPcnPmRKigaKEaXeKl9a5PCxxxIdjyfiFf99n3OA==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.15.1.tgz",
+      "integrity": "sha512-2ZCc4lVwK8O0cVisdizuYaZQZoc3ZUnB+qlTFEu2ch6mP+RO7mghqa0JQmwHs1tXUZyL20GAoWtK47oKC9DxUw==",
       "requires": {
         "fast-json-patch": "^3.0.0-1",
         "json-stringify-pretty-compact": "^2.0.0",
         "semver": "^7.3.4",
         "vega-schema-url-parser": "^2.1.0",
         "vega-themes": "^2.9.1",
-        "vega-tooltip": "^0.24.2"
+        "vega-tooltip": "^0.25.0"
       },
       "dependencies": {
         "semver": {
@@ -10851,9 +10665,9 @@
           }
         },
         "vega-tooltip": {
-          "version": "0.24.2",
-          "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.24.2.tgz",
-          "integrity": "sha512-b7IeYQl/piNVsMmTliOgTnwSOhBs67KqoZ9UzP1I3XpH7TKbSuc3YHA7b1CSxkRR0hHKdradby4UI8c9rdH74w==",
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.25.0.tgz",
+          "integrity": "sha512-S48d/eP6WfieLmUvFEjd+raHWKKeK/RfTlwLa3zGcBULDHJY2NU2vRfjC1x33G6Y7eKeAfqGpM6ER5Qt1nf8tA==",
           "requires": {
             "vega-util": "^1.15.2"
           }
@@ -10933,9 +10747,9 @@
       }
     },
     "vega-functions": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.10.0.tgz",
-      "integrity": "sha512-1l28OxUwOj8FEvRU62Oz2hiTuDECrvx1DPU1qLebBKhlgaKbcCk3XyHrn1kUzhMKpXq+SFv5VPxchZP47ASSvQ==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.12.0.tgz",
+      "integrity": "sha512-3hljmGs+gR7TbO/yYuvAP9P5laKISf1GKk4yRHLNdM61fWgKm8pI3f6LY2Hvq9cHQFTiJ3/5/Bx2p1SX5R4quQ==",
       "requires": {
         "d3-array": "^2.7.1",
         "d3-color": "^2.0.0",
@@ -10943,8 +10757,8 @@
         "vega-dataflow": "^5.7.3",
         "vega-expression": "^4.0.1",
         "vega-scale": "^7.1.1",
-        "vega-scenegraph": "^4.9.2",
-        "vega-selections": "^5.1.5",
+        "vega-scenegraph": "^4.9.3",
+        "vega-selections": "^5.3.0",
         "vega-statistics": "^1.7.9",
         "vega-time": "^2.0.4",
         "vega-util": "^1.16.0"
@@ -11123,11 +10937,6 @@
         }
       }
     },
-    "vega-lite-api": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/vega-lite-api/-/vega-lite-api-0.11.0.tgz",
-      "integrity": "sha512-1DdcP+o7Usg7TL0z2uO6JkjZ2TIH5Ljjwoyemxc9awwMJYPN1WyKQHeWmy9fuzPUkERfX/pIyEEjA5LX84yvCg=="
-    },
     "vega-loader": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.4.0.tgz",
@@ -11166,15 +10975,15 @@
       }
     },
     "vega-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.1.2.tgz",
-      "integrity": "sha512-aGyZrNzPrBruEb/WhemKDuDjQsIkMDGIgnSJci0b+9ZVxjyAzMl7UfGbiYorPiJlnIercjUJbMoFD6fCIf4gqQ==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.1.3.tgz",
+      "integrity": "sha512-8oiVhhW26GQ4GZBvolId8FVFvhn3s1KGgPlD7Z+4P2wkV+xe5Nqu0TEJ20F/cn3b88fd0Vj48X3BH3dlSeKNFg==",
       "requires": {
         "vega-dataflow": "^5.7.3",
         "vega-event-selector": "^2.0.6",
-        "vega-functions": "^5.10.0",
+        "vega-functions": "^5.12.0",
         "vega-scale": "^7.1.1",
-        "vega-util": "^1.15.2"
+        "vega-util": "^1.16.0"
       }
     },
     "vega-projection": {
@@ -11251,9 +11060,9 @@
       }
     },
     "vega-scenegraph": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.9.2.tgz",
-      "integrity": "sha512-epm1CxcB8AucXQlSDeFnmzy0FCj+HV2k9R6ch2lfLRln5lPLEfgJWgFcFhVf5jyheY0FSeHH52Q5zQn1vYI1Ow==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.9.3.tgz",
+      "integrity": "sha512-lBvqLbXqrqRCTGJmSgzZC/tLR/o+TXfakbdhDzNdpgTavTaQ65S/67Gpj5hPpi77DvsfZUIY9lCEeO37aJhy0Q==",
       "requires": {
         "d3-path": "^2.0.0",
         "d3-shape": "^2.0.0",
@@ -11269,12 +11078,12 @@
       "integrity": "sha512-JHT1PfOyVzOohj89uNunLPirs05Nf59isPT5gnwIkJph96rRgTIBJE7l7yLqndd7fLjr3P8JXHGAryRp74sCaQ=="
     },
     "vega-selections": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.1.5.tgz",
-      "integrity": "sha512-oRSsfkqYqA5xfEJqDpgnSDd+w0k6p6SGYisMD6rGXMxuPl0x0Uy6RvDr4nbEtB+dpWdoWEvgrsZVS6axyDNWvQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.3.0.tgz",
+      "integrity": "sha512-vC4NPsuN+IffruFXfH0L3i2A51RgG4PqpLv85TvrEAIYnSkyKDE4bf+wVraR3aPdnLLkc3+tYuMi6le5FmThIA==",
       "requires": {
-        "vega-expression": "^4.0.0",
-        "vega-util": "^1.15.2"
+        "vega-expression": "^4.0.1",
+        "vega-util": "^1.16.0"
       }
     },
     "vega-statistics": {
@@ -11388,21 +11197,21 @@
       }
     },
     "viewport-mercator-project": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/viewport-mercator-project/-/viewport-mercator-project-7.0.1.tgz",
-      "integrity": "sha512-WKTuTL7o6WKdPQ+gmZhlXL7UpSdCdPUjxkDTBd/3AayBdAFSQGHxsqdbmPBvmoGwvo9KWo/30HTkNo/Z7ORJpw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/viewport-mercator-project/-/viewport-mercator-project-7.0.2.tgz",
+      "integrity": "sha512-gH0pBO4Y5McGCPaKulkpL9MPDg+wtOSXtndwh0467T/WLMerfBi7EkHYw1pp9HE2VeqFqUaAfot98cQPGaIjEA==",
       "requires": {
-        "@math.gl/web-mercator": "^3.1.3"
+        "@math.gl/web-mercator": "^3.2.0"
       }
     },
     "vitessce": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-1.1.3.tgz",
-      "integrity": "sha512-tgBEZyWcchu5y7fRomkuh/ALKGYgOUBZMYpYsNx8e9SyUWqngCKDN2p8Eg8bGnBZOx3eZWKSmjbvWT6DkmumzA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-1.1.4.tgz",
+      "integrity": "sha512-ei8vve2CQCKiX0Mj2CAOCY4MnkgDb+xBVstLzWg2DxwCvdh9ayZwaCPPKq2jpzLv0P7Hsog1017dfRFrkD+HZw==",
       "requires": {
         "@deck.gl/core": "8.4.0-alpha.4",
         "@deck.gl/layers": "8.4.0-alpha.4",
-        "@hms-dbmi/viv": "^0.8.2",
+        "@hms-dbmi/viv": "^0.8.3",
         "@loaders.gl/3d-tiles": "^2.3.0",
         "@loaders.gl/core": "^2.3.0",
         "@loaders.gl/images": "^2.3.0",
@@ -11423,6 +11232,7 @@
         "ajv": "^6.10.0",
         "bowser": "^2.11.0",
         "classnames": "^2.2.6",
+        "clsx": "^1.1.1",
         "d3-array": "^2.4.0",
         "d3-dsv": "^1.1.1",
         "d3-force": "^2.1.1",
@@ -11438,6 +11248,7 @@
         "lodash": "^4.17.15",
         "lz-string": "^1.4.4",
         "math.gl": "^3.1.3",
+        "mathjs": "^9.2.0",
         "nebula.gl": "^0.21.1",
         "prop-types": "^15.7.2",
         "rc-tooltip": "^4.0.3",
@@ -11452,7 +11263,6 @@
         "uuid": "^3.3.2",
         "vega": "^5.13.0",
         "vega-lite": "^4.13.0",
-        "vega-lite-api": "^0.11.0",
         "vega-tooltip": "^0.23.0",
         "whatwg-fetch": "^3.0.0",
         "window-pixi": "5.3.3",
@@ -11986,9 +11796,9 @@
       }
     },
     "zustand": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.2.0.tgz",
-      "integrity": "sha512-MBYFrnUdgFVi38tdQNSzVN9cPpRDf7w2HhdHGDSgBRHN7vIbUGUR3aBdVQykelXzSFR7iVj3YNBuq7B9ceMI5w=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.3.1.tgz",
+      "integrity": "sha512-o0rgrBsi29nCkPHdhtkAHisCIlmRUoXOV+1AmDMeCgkGG0i5edFSpGU0KiZYBvFmBYycnck4Z07JsLYDjSET9g=="
     }
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -43,7 +43,7 @@
     "pubsub-js": "^1.9.0",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",
-    "vitessce": "^1.1.3"
+    "vitessce": "^1.1.4"
   },
   "jupyterlab": {
     "extension": "dist/labplugin",

--- a/vitessce/__init__.py
+++ b/vitessce/__init__.py
@@ -6,7 +6,6 @@ from .constants import CoordinationType, Component, DataType, FileType
 from .wrappers import (
     AbstractWrapper,
     OmeTiffWrapper,
-    OmeZarrWrapper,
     MultiImageWrapper,
     AnnDataWrapper,
     SnapWrapper,

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -681,7 +681,7 @@ class VitessceConfig:
         :param str base_url: Optional parameter for non-remote data to specify the url from which the data will be served.
 
         :returns: A list of server routes.
-	    :rtype: list[starlette.routing.Route]]
+        :rtype: list[starlette.routing.Route]]
         """
         routes = []            
         for d in self.config["datasets"]:

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -681,7 +681,7 @@ class VitessceConfig:
         :param str base_url: Optional parameter for non-remote data to specify the url from which the data will be served.
 
         :returns: A list of server routes.
-        :rtype: list[starlette.routing.Route]]
+        :rtype: list[starlette.routing.Route]
         """
         routes = []            
         for d in self.config["datasets"]:

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -654,8 +654,7 @@ class VitessceConfig:
         """
         Convert the view config instance to a dict object.
 
-        :param on_obj: This callback is required only if datasets within the view config contain objects added via the ``VitessceConfigDataset.add_object`` method (rather than only files added via the ``VitessceConfigDataset.add_file`` method). This function must take the data object as a parameter, and return a list of valid file definition dicts (URL, data type, file type). This parameter is primarily intended to be used internally by the ``VitessceWidget`` class.
-        :type on_obj: function or None
+        :param str base_url: Optional parameter for non-remote data to specify the url from which the data will be served.
 
         :returns: The view config as a dict. Useful for serializing to JSON.
         :rtype: dict
@@ -676,6 +675,14 @@ class VitessceConfig:
         }
     
     def get_routes(self, base_url=""):
+        """
+        Convert the routes for this view config from the datasets.
+
+        :param str base_url: Optional parameter for non-remote data to specify the url from which the data will be served.
+
+        :returns: A list of server routes.
+	    :rtype: list[starlette.routing.Route]]
+        """
         routes = []            
         for d in self.config["datasets"]:
             for obj_i, obj in enumerate(d.objs):

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -679,8 +679,8 @@ class VitessceConfig:
         routes = []            
         for d in self.config["datasets"]:
             for obj_i, obj in enumerate(d.objs):
-                route = create_obj_routes(obj, base_url, d.dataset["uid"], obj_i)
-                routes += [route]
+                obj_routes = create_obj_routes(obj, base_url, d.dataset["uid"], obj_i)
+                routes += obj_routes
         return routes
 
     @staticmethod

--- a/vitessce/export.py
+++ b/vitessce/export.py
@@ -7,7 +7,6 @@ from shutil import copyfile
 from starlette.routing import Route, Mount
 from starlette.staticfiles import StaticFiles
 
-from .routes import create_obj_routes
 from .wrappers import JsonRoute
 
 def export_to_s3(config, s3, bucket_name, prefix=''):
@@ -25,14 +24,8 @@ def export_to_s3(config, s3, bucket_name, prefix=''):
     
     base_url = f"https://{bucket_name}.s3.amazonaws.com" + ("/" + prefix if len(prefix) > 0 else "")
     bucket = s3.Bucket(bucket_name)
-    
-    routes = []
-    def on_obj(obj, dataset_uid, obj_i):
-        obj_file_defs, obj_routes = create_obj_routes(obj, base_url, dataset_uid, obj_i)
-        for obj_route in obj_routes:
-            routes.append(obj_route)
-        return obj_file_defs
-    config_dict = config.to_dict(on_obj=on_obj)
+    config_dict = config.to_dict(base_url=base_url)
+    routes = config.get_routes(base_url=base_url)
     uploaded_routes = []
     for route in routes:
         route_path = route.path[1:]
@@ -69,14 +62,8 @@ def export_to_files(config, base_url, out_dir='.'):
     :rtype: dict
     """
     
-    routes = []
-    def on_obj(obj, dataset_uid, obj_i):
-        obj_file_defs, obj_routes = create_obj_routes(obj, base_url, dataset_uid, obj_i)
-        for obj_route in obj_routes:
-            routes.append(obj_route)
-        return obj_file_defs
-    config_dict = config.to_dict(on_obj=on_obj)
-
+    config_dict = config.to_dict(base_url=base_url)
+    routes = config.get_routes(base_url=base_url)
     for route in routes:
         route_path = route.path[1:]
         out_path = join(out_dir, route_path)

--- a/vitessce/routes.py
+++ b/vitessce/routes.py
@@ -5,16 +5,13 @@ from .constants import DataType as dt
 
 def create_obj_routes(obj, base_url, dataset_uid, obj_i):
 	"""
-	For a particular data object, simultaneously set up:
-	
-	* its server routes and their responses, and
-	* the corresponding view config dataset file definitions
+	For a particular data object, simultaneously set up its server routes and their responses
 
 	:param obj: An object representing a single-cell data analysis result or microscopy image.
 	:type obj: anndata.AnnData or loompy.LoomConnection or zarr.hierarchy.Group
 	
 	:returns: A list of view config file definitions and a list of server routes.
-	:rtype: tuple[list[dict], list[starlette.routing.Route]]
+	:rtype: list[starlette.routing.Route]]
 	"""
 	obj_routes = []
 
@@ -29,16 +26,13 @@ def create_obj_routes(obj, base_url, dataset_uid, obj_i):
 
 def create_obj_files(obj, base_url, dataset_uid, obj_i):
 	"""
-	For a particular data object, simultaneously set up:
-	
-	* its server routes and their responses, and
-	* the corresponding view config dataset file definitions
+	For a particular data object, set up view config dataset file definitions
 
 	:param obj: An object representing a single-cell data analysis result or microscopy image.
 	:type obj: anndata.AnnData or loompy.LoomConnection or zarr.hierarchy.Group
 	
 	:returns: A list of view config file definitions and a list of server routes.
-	:rtype: tuple[list[dict], list[starlette.routing.Route]]
+	:rtype: tuple[list[dict]
 	"""
 	obj_file_defs = []
 

--- a/vitessce/routes.py
+++ b/vitessce/routes.py
@@ -10,7 +10,7 @@ def create_obj_routes(obj, base_url, dataset_uid, obj_i):
 	:param obj: An object representing a single-cell data analysis result or microscopy image.
 	:type obj: anndata.AnnData or loompy.LoomConnection or zarr.hierarchy.Group
 	
-	:returns: A list of view config file definitions and a list of server routes.
+	:returns: A list of server routes.
 	:rtype: list[starlette.routing.Route]]
 	"""
 	obj_routes = []
@@ -31,7 +31,7 @@ def create_obj_files(obj, base_url, dataset_uid, obj_i):
 	:param obj: An object representing a single-cell data analysis result or microscopy image.
 	:type obj: anndata.AnnData or loompy.LoomConnection or zarr.hierarchy.Group
 	
-	:returns: A list of view config file definitions and a list of server routes.
+	:returns: A list of view config file definitions
 	:rtype: tuple[list[dict]
 	"""
 	obj_file_defs = []

--- a/vitessce/routes.py
+++ b/vitessce/routes.py
@@ -16,18 +16,40 @@ def create_obj_routes(obj, base_url, dataset_uid, obj_i):
 	:returns: A list of view config file definitions and a list of server routes.
 	:rtype: tuple[list[dict], list[starlette.routing.Route]]
 	"""
-	obj_file_defs = []
 	obj_routes = []
 
 	for data_type in dt:
 		try:
-			dt_obj_file_defs, dt_obj_routes = obj._get_data(data_type, base_url, dataset_uid, obj_i)
-			obj_file_defs += dt_obj_file_defs
+			_, dt_obj_routes = obj._get_data(data_type, base_url, dataset_uid, obj_i)
 			obj_routes += dt_obj_routes
 		except NotImplementedError:
 			pass
 
-	return obj_file_defs, obj_routes
+	return obj_routes
+
+def create_obj_files(obj, base_url, dataset_uid, obj_i):
+	"""
+	For a particular data object, simultaneously set up:
+	
+	* its server routes and their responses, and
+	* the corresponding view config dataset file definitions
+
+	:param obj: An object representing a single-cell data analysis result or microscopy image.
+	:type obj: anndata.AnnData or loompy.LoomConnection or zarr.hierarchy.Group
+	
+	:returns: A list of view config file definitions and a list of server routes.
+	:rtype: tuple[list[dict], list[starlette.routing.Route]]
+	"""
+	obj_file_defs = []
+
+	for data_type in dt:
+		try:
+			dt_obj_file_defs, _ = obj._get_data(data_type, base_url, dataset_uid, obj_i)
+			obj_file_defs += dt_obj_file_defs
+		except NotImplementedError:
+			pass
+
+	return obj_file_defs
 
 # Adapted from https://gist.github.com/tombulled/712fd8e19ed0618c5f9f7d5f5f543782
 def ranged(file, start = 0, end = None, block_size = 65535):

--- a/vitessce/routes.py
+++ b/vitessce/routes.py
@@ -5,7 +5,7 @@ from .constants import DataType as dt
 
 def create_obj_routes(obj, base_url, dataset_uid, obj_i):
 	"""
-	For a particular data object, simultaneously set up its server routes and their responses
+	For a particular data object, set up its server routes and their responses
 
 	:param obj: An object representing a single-cell data analysis result or microscopy image.
 	:type obj: anndata.AnnData or loompy.LoomConnection or zarr.hierarchy.Group

--- a/vitessce/routes.py
+++ b/vitessce/routes.py
@@ -11,7 +11,7 @@ def create_obj_routes(obj, base_url, dataset_uid, obj_i):
 	:type obj: anndata.AnnData or loompy.LoomConnection or zarr.hierarchy.Group
 	
 	:returns: A list of server routes.
-	:rtype: list[starlette.routing.Route]]
+	:rtype: list[starlette.routing.Route]
 	"""
 	obj_routes = []
 
@@ -32,7 +32,7 @@ def create_obj_files(obj, base_url, dataset_uid, obj_i):
 	:type obj: anndata.AnnData or loompy.LoomConnection or zarr.hierarchy.Group
 	
 	:returns: A list of view config file definitions
-	:rtype: tuple[list[dict]
+	:rtype: list[dict]
 	"""
 	obj_file_defs = []
 

--- a/vitessce/widget.py
+++ b/vitessce/widget.py
@@ -112,13 +112,8 @@ class VitessceWidget(widgets.DOMWidget):
         else:
             base_url = f"http://localhost:{use_port}"
 
-        routes = []
-        def on_obj(obj, dataset_uid, obj_i):
-            obj_file_defs, obj_routes = create_obj_routes(obj, base_url, dataset_uid, obj_i)
-            for obj_route in obj_routes:
-                routes.append(obj_route)
-            return obj_file_defs
-        config_dict = config.to_dict(on_obj=on_obj)
+        config_dict = config.to_dict(base_url=base_url)
+        routes = config.get_routes(base_url=base_url)
 
         super(VitessceWidget, self).__init__(config=config_dict, height=height, theme=theme, proxy=proxy)
         

--- a/vitessce/widget.py
+++ b/vitessce/widget.py
@@ -113,7 +113,7 @@ class VitessceWidget(widgets.DOMWidget):
             base_url = f"http://localhost:{use_port}"
 
         config_dict = config.to_dict(base_url=base_url)
-        routes = config.get_routes(base_url=base_url)
+        routes = config.get_routes()
 
         super(VitessceWidget, self).__init__(config=config_dict, height=height, theme=theme, proxy=proxy)
         

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -508,7 +508,8 @@ class AnnDataWrapper(AbstractWrapper):
     
     def auto_view_config(self, vc):
         dataset = vc.add_dataset().add_object(self)
-        scatterplot = vc.add_view(dataset, cm.SCATTERPLOT, mapping=self._mappings_obsm[0].split('/')[-1])
+        mapping_name = self._mappings_obsm_names[0] if (self._mappings_obsm_names is not None) else self._mappings_obsm[0].split('/')[-1]
+        scatterplot = vc.add_view(dataset, cm.SCATTERPLOT, mapping=mapping_name)
         cell_sets = vc.add_view(dataset, cm.CELL_SETS)
         genes = vc.add_view(dataset, cm.GENES)
         heatmap = vc.add_view(dataset, cm.HEATMAP)

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -73,7 +73,9 @@ class AbstractWrapper:
         """
         file_defs_with_base_url = []
         for file_def_creator in self.file_def_creators:
-            file_defs_with_base_url.append(file_def_creator(base_url))
+            file_def = file_def_creator(base_url)
+            if file_def is not None:
+                file_defs_with_base_url.append(file_def)
         return file_defs_with_base_url
 
     def _get_url(self, base_url, dataset_uid, obj_i, *args):
@@ -98,7 +100,6 @@ class MultiImageWrapper(AbstractWrapper):
         self.use_physical_size_scaling = use_physical_size_scaling
     
     def convert_and_save(self, dataset_uid, obj_i):
-        super().convert_and_save(dataset_uid, obj_i)
         for image in self.image_wrappers:
             image.convert_and_save(dataset_uid, obj_i)
         file_def_creator = self.make_raster_file_def_creator(dataset_uid, obj_i)
@@ -157,8 +158,10 @@ class OmeTiffWrapper(AbstractWrapper):
         if img_url is not None and (img_path is not None or offsets_path is not None):
             raise ValueError("Did not expect img_path or offsets_path to be provided with img_url")
     
-    def convert_and_save(self, dataset_uid, obj_i):   
-        super().convert_and_save(dataset_uid, obj_i)
+    def convert_and_save(self, dataset_uid, obj_i):
+        # Only create out-directory if needed
+        if not self.is_remote:   
+            super().convert_and_save(dataset_uid, obj_i)
         file_def_creator = self.make_raster_file_def_creator(dataset_uid, obj_i)
         routes = self.make_raster_routes(dataset_uid, obj_i)
         self.file_def_creators.append(file_def_creator)
@@ -339,25 +342,35 @@ class AnnDataWrapper(AbstractWrapper):
         :param \*\*kwargs: Keyword arguments inherited from :class:`~vitessce.wrappers.AbstractWrapper`
         """
         super().__init__(**kwargs)
+        self._adata = adata
+        self._adata_url = adata_url
         if adata is not None:
-            self.adata = adata
-            self._zarr_filepath = join(tempfile.mkdtemp(), 'anndata.zarr')
-            self._adata_url = adata_url
-            adata.write_zarr(self._zarr_filepath)
+            self.is_remote = False
         else:
-            self.adata = adata
-            self._adata_url = adata_url
-            self._zarr_filepath = None
-        self.expression_matrix = expression_matrix
-        self.cell_set_obs_names = cell_set_obs_names
-        self.mappings_obsm_names = mappings_obsm_names
-        self.genes_var_filter = "var/" + genes_var_filter if genes_var_filter is not None else genes_var_filter
-        self.cell_set_obs = ["obs/" + i for i in cell_set_obs] if cell_set_obs is not None else cell_set_obs
-        self.spatial_centroid_obsm = "obsm/" + spatial_centroid_obsm if spatial_centroid_obsm is not None else spatial_centroid_obsm
-        self.spatial_polygon_obsm = "obsm/" + spatial_polygon_obsm if spatial_polygon_obsm is not None else spatial_polygon_obsm
-        self.mappings_obsm = ["obsm/" + i for i in mappings_obsm] if mappings_obsm is not None else mappings_obsm
-        self.mappings_obsm_dims = mappings_obsm_dims
-    
+            self.is_remote = True
+        self._expression_matrix = expression_matrix
+        self._cell_set_obs_names = cell_set_obs_names
+        self._mappings_obsm_names = mappings_obsm_names
+        self._genes_var_filter = "var/" + genes_var_filter if genes_var_filter is not None else genes_var_filter
+        self._cell_set_obs = ["obs/" + i for i in cell_set_obs] if cell_set_obs is not None else cell_set_obs
+        self._spatial_centroid_obsm = "obsm/" + spatial_centroid_obsm if spatial_centroid_obsm is not None else spatial_centroid_obsm
+        self._spatial_polygon_obsm = "obsm/" + spatial_polygon_obsm if spatial_polygon_obsm is not None else spatial_polygon_obsm
+        self._mappings_obsm = ["obsm/" + i for i in mappings_obsm] if mappings_obsm is not None else mappings_obsm
+        self._mappings_obsm_dims = mappings_obsm_dims
+
+    def convert_and_save(self, dataset_uid, obj_i):
+        # Only create out-directory if needed
+        if not self.is_remote:   
+            super().convert_and_save(dataset_uid, obj_i)
+            out_dir = self._get_out_dir(dataset_uid, obj_i)
+            self._zarr_filepath = join(out_dir, 'anndata.zarr')
+            self._adata.write_zarr(self._zarr_filepath)
+        cells_file_creator = self.make_cells_file_def_creator(dataset_uid, obj_i)
+        cell_sets_file_creator = self.make_cell_sets_file_def_creator(dataset_uid, obj_i)
+        expression_matrix_file_creator = self.make_expression_matrix_file_def_creator(dataset_uid, obj_i)
+        self.file_def_creators += [cells_file_creator, cell_sets_file_creator, expression_matrix_file_creator] 
+        self.routes += self.get_route(dataset_uid, obj_i)
+
     def _get_zarr_dir(self):
         return os.path.basename(self._zarr_filepath if self._zarr_filepath is not None else self._adata_url)
     
@@ -367,94 +380,98 @@ class AnnDataWrapper(AbstractWrapper):
         else:
             return self._get_url(base_url, dataset_uid, obj_i, self._get_zarr_dir())
     
+    def make_cells_file_def_creator(self, dataset_uid, obj_i):
+        def get_cells(base_url):
+            options = {}
+            if self._spatial_centroid_obsm is not None:
+                options["xy"] = self._spatial_centroid_obsm
+            if self._spatial_polygon_obsm is not None:
+                options["poly"] = self._spatial_polygon_obsm
+            if self._mappings_obsm is not None:
+                options["mappings"] = {}
+                if self._mappings_obsm_names is not None:
+                    for key, mapping in zip(self._mappings_obsm_names, self._mappings_obsm): 
+                        options["mappings"][key] = {
+                            "key": mapping,
+                            "dims": [0, 1]
+                        }
+                else:
+                    for mapping in self._mappings_obsm:
+                        mapping_key = mapping.split('/')[-1]
+                        self._mappings_obsm_names = mapping_key
+                        options["mappings"][mapping_key] = {
+                            "key": mapping,
+                            "dims": [0, 1]
+                        }
+                if self._mappings_obsm_dims is not None:
+                    for dim, key in zip(self._mappings_obsm_dims, self._mappings_obsm_names):
+                        options["mappings"][key]['dims'] = dim
+            if self._cell_set_obs is not None:
+                options["factors"] = []
+                for obs in self._cell_set_obs:
+                    options["factors"].append(obs)
+            if len(options.keys()) > 0:
+                obj_file_def = {
+                    "type": dt.CELLS.value,
+                    "fileType": ft.ANNDATA_CELLS_ZARR.value,
+                    "url": self.get_zarr_url(base_url, dataset_uid, obj_i),
+                    "options": options
+                }
+                
 
-    def get_cells(self, base_url, dataset_uid, obj_i):
-        options = {}
-        if self.spatial_centroid_obsm is not None:
-            options["xy"] = self.spatial_centroid_obsm
-        if self.spatial_polygon_obsm is not None:
-            options["poly"] = self.spatial_polygon_obsm
-        if self.mappings_obsm is not None:
-            options["mappings"] = {}
-            if self.mappings_obsm_names is not None:
-                for key, mapping in zip(self.mappings_obsm_names, self.mappings_obsm): 
-                    options["mappings"][key] = {
-                        "key": mapping,
-                        "dims": [0, 1]
-                    }
-            else:
-                for mapping in self.mappings_obsm:
-                    mapping_key = mapping.split('/')[-1]
-                    self.mappings_obsm_names = mapping_key
-                    options["mappings"][mapping_key] = {
-                        "key": mapping,
-                        "dims": [0, 1]
-                    }
-            if self.mappings_obsm_dims is not None:
-                for dim, key in zip(self.mappings_obsm_dims, self.mappings_obsm_names):
-                    options["mappings"][key]['dims'] = dim
-        if self.cell_set_obs is not None:
-            options["factors"] = []
-            for obs in self.cell_set_obs:
-                options["factors"].append(obs)
-        obj_file_defs = [
-            {
-                "type": dt.CELLS.value,
-                "fileType": ft.ANNDATA_CELLS_ZARR.value,
-                "url": self.get_zarr_url(base_url, dataset_uid, obj_i),
-                "options": options
-            }
-        ]
-        obj_routes = [self.get_route(dataset_uid, obj_i)]
-
-        return obj_file_defs, obj_routes
+                return obj_file_def
+            return None
+        return get_cells
     
     def get_route(self, dataset_uid, obj_i):
-        return Mount(self._get_route(dataset_uid, obj_i, self._get_zarr_dir()),
-                        app=StaticFiles(directory=self._zarr_filepath, html=False))
+        if self.is_remote is not True:
+            return [Mount(self._get_route(dataset_uid, obj_i, self._get_zarr_dir()),
+                            app=StaticFiles(directory=self._zarr_filepath, html=False))]
+        return []
 
-    def get_cell_sets(self, base_url, dataset_uid, obj_i):
-        obj_file_defs = []
-        obj_routes = [self.get_route(dataset_uid, obj_i)]
-        if self.cell_set_obs is not None:
-            options = []
-            if self.cell_set_obs_names is not None:
-                names = self.cell_set_obs_names
-            else:
-                names = [obs.split('/')[-1] for obs in self.cell_set_obs]
-            for obs, name in zip(self.cell_set_obs, names):
-                options.append({
-                    "groupName": name,
-                    "setName": obs
-                })
+    def make_cell_sets_file_def_creator(self, dataset_uid, obj_i):
+        def get_cell_sets(base_url):
+            if self._cell_set_obs is not None:
+                options = []
+                if self._cell_set_obs_names is not None:
+                    names = self._cell_set_obs_names
+                else:
+                    names = [obs.split('/')[-1] for obs in self._cell_set_obs]
+                for obs, name in zip(self._cell_set_obs, names):
+                    options.append({
+                        "groupName": name,
+                        "setName": obs
+                    })
 
-            obj_file_defs = [
-                {
+                obj_file_def = {
                     "type": dt.CELL_SETS.value,
                     "fileType": ft.ANNDATA_CELL_SETS_ZARR.value,
                     "url": self.get_zarr_url(base_url, dataset_uid, obj_i),
                     "options": options
                 }
-            ]
-        return obj_file_defs, obj_routes
-    
-    def get_expression_matrix(self, base_url, dataset_uid, obj_i):
-        options = {}
-        obj_routes = [self.get_route(dataset_uid, obj_i)]
-        obj_file_defs = []
-        if self.expression_matrix is not None:
-            options["matrix"] = self.expression_matrix
-            if self.genes_var_filter is not None:
-                options["geneFilter"] = self.genes_var_filter
-            obj_file_defs = [
-                {
+                
+                return obj_file_def
+            return None
+        return get_cell_sets
+
+    def make_expression_matrix_file_def_creator(self, dataset_uid, obj_i):
+        def get_expression_matrix(base_url):
+            options = {}
+            obj_file_defs = []
+            if self._expression_matrix is not None:
+                options["matrix"] = self._expression_matrix
+                if self._genes_var_filter is not None:
+                    options["geneFilter"] = self._genes_var_filter
+                obj_file_def = {
                     "type": dt.EXPRESSION_MATRIX.value,
                     "fileType": ft.ANNDATA_EXPRESSION_MATRIX_ZARR.value,
                     "url": self.get_zarr_url(base_url, dataset_uid, obj_i),
                     "options": options
                 }
-            ]
-        return obj_file_defs, obj_routes
+                
+                return obj_file_def
+            return None
+        return get_expression_matrix
 
 class SnapWrapper(AbstractWrapper):
 
@@ -478,6 +495,15 @@ class SnapWrapper(AbstractWrapper):
         # Convert to dense matrix if sparse.
         if type(in_mtx) == coo_matrix:
             self.in_mtx = in_mtx.toarray()
+    
+    def convert_and_save(self, dataset_uid, obj_i):
+        print("Please wait, the following conversion is slow")
+        zarr_tempdir = self.tempdir
+        zarr_filepath = join(zarr_tempdir, 'profiles.zarr')
+        self.create_genomic_multivec_zarr(zarr_filepath)
+        file_def_creator = self.make_raster_file_def_creator(dataset_uid, obj_i)
+        routes = self.make_raster_routes(dataset_uid, obj_i)
+        self.file_def_creators.append(file_def_creator)
 
 
     def create_genomic_multivec_zarr(self, zarr_filepath):
@@ -628,9 +654,6 @@ class SnapWrapper(AbstractWrapper):
         
         zarr_tempdir = self.tempdir
         zarr_filepath = join(zarr_tempdir, 'profiles.zarr')
-
-        print("Please wait, the following conversion is slow")
-        self.create_genomic_multivec_zarr(zarr_filepath)
 
         if zarr_tempdir is not None:
             obj_routes = [

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -182,13 +182,15 @@ class MultiImageWrapper(AbstractWrapper):
     :param list image_wrappers: A list of imaging wrapper classes (only :class:`~vitessce.wrappers.OmeTiffWrapper` supported now)
     :param \*\*kwargs: Keyword arguments inherited from :class:`~vitessce.wrappers.AbstractWrapper`
     """
-    def __init__(self, image_wrappers, **kwargs):
+    def __init__(self, image_wrappers, use_physical_size_scaling=False, **kwargs):
         super().__init__(**kwargs)
         self.image_wrappers = image_wrappers
+        self.use_physical_size_scaling = use_physical_size_scaling
 
     def create_raster_json(self, base_url="", dataset_uid="", obj_i=""):
         raster_json = {
             "schemaVersion": "0.0.2",
+            "usePhysicalSizeScaling": self.use_physical_size_scaling,
             "images": [],
             "renderLayers": []
         }

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -346,8 +346,10 @@ class AnnDataWrapper(AbstractWrapper):
         self._adata_url = adata_url
         if adata is not None:
             self.is_remote = False
+            self.zarr_folder = 'anndata.zarr'
         else:
             self.is_remote = True
+            self.zarr_folder = None
         self._expression_matrix = expression_matrix
         self._cell_set_obs_names = cell_set_obs_names
         self._mappings_obsm_names = mappings_obsm_names
@@ -372,7 +374,7 @@ class AnnDataWrapper(AbstractWrapper):
     
     def get_zarr_path(self, dataset_uid, obj_i):
         out_dir = self._get_out_dir(dataset_uid, obj_i)
-        zarr_filepath = join(out_dir, 'anndata.zarr')
+        zarr_filepath = join(out_dir, self.zarr_folder)
         return zarr_filepath
         
 
@@ -380,7 +382,7 @@ class AnnDataWrapper(AbstractWrapper):
         if self.is_remote:
             return self._adata_url
         else:
-            return self._get_url(base_url, dataset_uid, obj_i, 'anndata.zarr')
+            return self._get_url(base_url, dataset_uid, obj_i, self.zarr_folder)
     
     def make_cells_file_def_creator(self, dataset_uid, obj_i):
         def get_cells(base_url):
@@ -489,7 +491,7 @@ class SnapWrapper(AbstractWrapper):
         self.in_barcodes_df = in_barcodes_df # pandas dataframe (barcodes.txt)
         self.in_bins_df = in_bins_df # pandas dataframe (bins.txt)
         self.in_clusters_df = in_clusters_df # pandas dataframe (umap_coords_clusters.csv)
-
+        self.zarr_folder = 'profiles.zarr'
 
         self.starting_resolution = starting_resolution
 
@@ -500,7 +502,7 @@ class SnapWrapper(AbstractWrapper):
     def convert_and_save(self, dataset_uid, obj_i):
         super().convert_and_save(dataset_uid, obj_i)
         out_dir = self._get_out_dir(dataset_uid, obj_i)
-        zarr_filepath = join(out_dir, 'profiles.zarr')
+        zarr_filepath = join(out_dir, self.zarr_folder)
         self.create_genomic_multivec_zarr(zarr_filepath)
         with open(join(out_dir, 'cell-sets'), 'w') as f:
             f.write(json.dumps(self.create_cell_sets_json()))
@@ -663,7 +665,7 @@ class SnapWrapper(AbstractWrapper):
             return {
                 "type": dt.GENOMIC_PROFILES.value,
                 "fileType": ft.GENOMIC_PROFILES_ZARR.value,
-                "url": self._get_url(base_url, dataset_uid, obj_i, "profiles.zarr")
+                "url": self._get_url(base_url, dataset_uid, obj_i, self.zarr_folder)
             }
         
         return get_genomic_profiles


### PR DESCRIPTION
In this PR, I get rid of `on_obj` call back for `to_dict` on the view config object and internalize it by creating a new method on the configuration class, `get_routes`, to handle the behavior that `on_obj` seems to be used for repeatedly.

In the portal, we want to be able to call `to_dict` without any arguments and get the view config with the URLs from the wrappers/files.  In the current setup `to_dict` returns a view config with empty `files` field because it has no way of constructing the URLs with the `on_obj` callback.  The only catch with this method is that for local data, if you do not pass in a `base_url`, you could get back out a view config with completely unusable urls (as opposed to before, where `files` would just be empty).