### PR TITLE
Fix select css

### DIFF
--- a/js/lib/widget.css
+++ b/js/lib/widget.css
@@ -14,3 +14,7 @@
 .vitessce-container .layer-controller-container select {
     height: revert;
 }
+
+html {
+    font-size: 14px;
+}

--- a/js/lib/widget.css
+++ b/js/lib/widget.css
@@ -10,3 +10,7 @@
 .vitessce-container div {
     font-size: 14px;
 }
+
+.vitessce-container .layer-controller-container select {
+    height: revert;
+}

--- a/js/lib/widget.js
+++ b/js/lib/widget.js
@@ -63,7 +63,8 @@ function VitessceWidget(props) {
         jpn.style.overflow = "hidden";
       }
     }
-    function handleMouseLeave() {
+    function handleMouseLeave(event) {
+      if(event.relatedTarget === null || (event.relatedTarget && event.relatedTarget.closest('.jp-Notebook')?.length)) return;
       const jpn = divRef.current.closest('.jp-Notebook');
       if(jpn) {
         jpn.style.overflow = "auto";


### PR DESCRIPTION
This PR fixes the issue of `<select` element heights being too small. It goes along with the checkbox height issue and the classic notebook interface font sizing issue.