### PR TITLE
Add repr()

### DIFF
--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -53,7 +53,7 @@ class AbstractWrapper:
         self.file_def_creators = []
 
     def __repr__(self):
-        return self.repr
+        return self._repr
 
     def convert_and_save(self, dataset_uid, obj_i):
         """
@@ -159,7 +159,7 @@ class MultiImageWrapper(AbstractWrapper):
     """
     def __init__(self, image_wrappers, use_physical_size_scaling=False, **kwargs):
         super().__init__(**kwargs)
-        self.repr = _make_repr(locals())
+        self._repr = _make_repr(locals())
         self.image_wrappers = image_wrappers
         self.use_physical_size_scaling = use_physical_size_scaling
     
@@ -213,7 +213,7 @@ class OmeTiffWrapper(AbstractWrapper):
 
     def __init__(self, img_path=None, offsets_path=None, img_url=None, offsets_url=None, name="", transformation_matrix=None, **kwargs):
         super().__init__(**kwargs)
-        self.repr = _make_repr(locals())
+        self._repr = _make_repr(locals())
         self.name = name
         self._img_path = img_path
         self._img_url = img_url
@@ -409,7 +409,7 @@ class AnnDataWrapper(AbstractWrapper):
         :param \\*\\*kwargs: Keyword arguments inherited from :class:`~vitessce.wrappers.AbstractWrapper`
         """
         super().__init__(**kwargs)
-        self.repr = _make_repr(locals())
+        self._repr = _make_repr(locals())
         self._adata = adata
         self._adata_url = adata_url
         if adata is not None:
@@ -576,7 +576,7 @@ class SnapWrapper(AbstractWrapper):
 
     def __init__(self, in_mtx, in_barcodes_df, in_bins_df, in_clusters_df, starting_resolution=5000, **kwargs):
         super().__init__(**kwargs)
-        self.repr = _make_repr(locals())
+        self._repr = _make_repr(locals())
         self.in_mtx = in_mtx # scipy.sparse.coo.coo_matrix (filtered_cell_by_bin.mtx)
         self.in_barcodes_df = in_barcodes_df # pandas dataframe (barcodes.txt)
         self.in_bins_df = in_bins_df # pandas dataframe (bins.txt)

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -128,15 +128,16 @@ class AbstractWrapper:
         raise NotImplementedError("Auto view configuration has not yet been implemented for this data object wrapper class.")
 
 
-def _make_repr(obj, args):
-    """
-    >>> _make_repr(Exception(), {'answer': 42})
-    'Exception(answer=42)'
-
-    """
-    obj_name = obj.__class__.__name__
+def _make_repr(init_locals):
+    del init_locals['self']
+    clazz = init_locals.pop('__class__')
+    kwargs = init_locals.pop('kwargs')
+    args = {
+        **init_locals,
+        **kwargs
+    }
     params = ', '.join([f'{k}={repr(v)}' for k, v in args.items()])
-    return f'{obj_name}({params})'
+    return f'{clazz.__name__}({params})'
 
 
 class MultiImageWrapper(AbstractWrapper):
@@ -148,14 +149,7 @@ class MultiImageWrapper(AbstractWrapper):
     """
     def __init__(self, image_wrappers, use_physical_size_scaling=False, **kwargs):
         super().__init__(**kwargs)
-        args = locals()
-        del args['self']
-        del args['kwargs']
-        del args['__class__']
-        self.repr = _make_repr(self, {
-            **args,
-            **kwargs
-        })
+        self.repr = _make_repr(locals())
         self.image_wrappers = image_wrappers
         self.use_physical_size_scaling = use_physical_size_scaling
 

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -132,8 +132,16 @@ class AbstractWrapper:
 
 
 def _make_repr(init_locals):
+    '''
+    >>> orig = MultiImageWrapper('IMAGE_WRAPPERS', foo='bar')
+    >>> orig_repr = repr(orig)
+    >>> print(orig_repr)
+    MultiImageWrapper(image_wrappers='IMAGE_WRAPPERS', use_physical_size_scaling=False, foo='bar')
+    >>> evalled = eval(orig_repr)
+    >>> assert orig_repr == repr(evalled)
+    '''
     del init_locals['self']
-    clazz = init_locals.pop('__class__')
+    clazz = init_locals.pop('__class__')  # Requires superclass to be initialized.
     kwargs = init_locals.pop('kwargs')
     args = {
         **init_locals,
@@ -146,13 +154,6 @@ def _make_repr(init_locals):
 class MultiImageWrapper(AbstractWrapper):
     """
     Wrap multiple imaging datasets by creating an instance of the ``MultiImageWrapper`` class.
-
-    >>> orig = MultiImageWrapper('IMAGE_WRAPPERS', foo='bar')
-    >>> orig_repr = repr(orig)
-    >>> print(orig_repr)
-    MultiImageWrapper(image_wrappers='IMAGE_WRAPPERS', use_physical_size_scaling=False, foo='bar')
-    >>> evalled = eval(orig_repr)
-    >>> assert orig_repr == repr(evalled)
 
     :param list image_wrappers: A list of imaging wrapper classes (only :class:`~vitessce.wrappers.OmeTiffWrapper` supported now)
     :param \\*\\*kwargs: Keyword arguments inherited from :class:`~vitessce.wrappers.AbstractWrapper`

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -39,11 +39,6 @@ class AbstractWrapper:
     """
     An abstract class that can be extended when
     implementing custom dataset object wrapper classes. 
-
-    TODO: Add some useful tests.
-
-    >>> assert True
-
     """
 
     def __init__(self, **kwargs):
@@ -162,6 +157,14 @@ class MultiImageWrapper(AbstractWrapper):
         self.use_physical_size_scaling = use_physical_size_scaling
 
     def __repr__(self):
+        '''
+        >>> orig = MultiImageWrapper('IMAGE_WRAPPERS', foo='bar')
+        >>> orig_repr = repr(orig)
+        >>> print(orig_repr)
+        MultiImageWrapper(image_wrappers='IMAGE_WRAPPERS', use_physical_size_scaling=False, foo='bar')
+        >>> evalled = eval(orig_repr)
+        >>> assert orig_repr == repr(evalled)
+        '''
         return self.repr
     
     def convert_and_save(self, dataset_uid, obj_i):

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -213,6 +213,7 @@ class OmeTiffWrapper(AbstractWrapper):
 
     def __init__(self, img_path=None, offsets_path=None, img_url=None, offsets_url=None, name="", transformation_matrix=None, **kwargs):
         super().__init__(**kwargs)
+        self.repr = _make_repr(locals())
         self.name = name
         self._img_path = img_path
         self._img_url = img_url
@@ -408,6 +409,7 @@ class AnnDataWrapper(AbstractWrapper):
         :param \\*\\*kwargs: Keyword arguments inherited from :class:`~vitessce.wrappers.AbstractWrapper`
         """
         super().__init__(**kwargs)
+        self.repr = _make_repr(locals())
         self._adata = adata
         self._adata_url = adata_url
         if adata is not None:
@@ -574,6 +576,7 @@ class SnapWrapper(AbstractWrapper):
 
     def __init__(self, in_mtx, in_barcodes_df, in_bins_df, in_clusters_df, starting_resolution=5000, **kwargs):
         super().__init__(**kwargs)
+        self.repr = _make_repr(locals())
         self.in_mtx = in_mtx # scipy.sparse.coo.coo_matrix (filtered_cell_by_bin.mtx)
         self.in_barcodes_df = in_barcodes_df # pandas dataframe (barcodes.txt)
         self.in_bins_df = in_bins_df # pandas dataframe (bins.txt)

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -52,6 +52,9 @@ class AbstractWrapper:
         self.is_remote = False
         self.file_def_creators = []
 
+    def __repr__(self):
+        return self.repr
+
     def convert_and_save(self, dataset_uid, obj_i):
         """
         Fill in the file_def_creators array.
@@ -144,6 +147,13 @@ class MultiImageWrapper(AbstractWrapper):
     """
     Wrap multiple imaging datasets by creating an instance of the ``MultiImageWrapper`` class.
 
+    >>> orig = MultiImageWrapper('IMAGE_WRAPPERS', foo='bar')
+    >>> orig_repr = repr(orig)
+    >>> print(orig_repr)
+    MultiImageWrapper(image_wrappers='IMAGE_WRAPPERS', use_physical_size_scaling=False, foo='bar')
+    >>> evalled = eval(orig_repr)
+    >>> assert orig_repr == repr(evalled)
+
     :param list image_wrappers: A list of imaging wrapper classes (only :class:`~vitessce.wrappers.OmeTiffWrapper` supported now)
     :param \\*\\*kwargs: Keyword arguments inherited from :class:`~vitessce.wrappers.AbstractWrapper`
     """
@@ -152,17 +162,6 @@ class MultiImageWrapper(AbstractWrapper):
         self.repr = _make_repr(locals())
         self.image_wrappers = image_wrappers
         self.use_physical_size_scaling = use_physical_size_scaling
-
-    def __repr__(self):
-        '''
-        >>> orig = MultiImageWrapper('IMAGE_WRAPPERS', foo='bar')
-        >>> orig_repr = repr(orig)
-        >>> print(orig_repr)
-        MultiImageWrapper(image_wrappers='IMAGE_WRAPPERS', use_physical_size_scaling=False, foo='bar')
-        >>> evalled = eval(orig_repr)
-        >>> assert orig_repr == repr(evalled)
-        '''
-        return self.repr
     
     def convert_and_save(self, dataset_uid, obj_i):
         for image in self.image_wrappers:

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -148,9 +148,12 @@ class MultiImageWrapper(AbstractWrapper):
     """
     def __init__(self, image_wrappers, use_physical_size_scaling=False, **kwargs):
         super().__init__(**kwargs)
+        args = locals()
+        del args['self']
+        del args['kwargs']
+        del args['__class__']
         self.repr = _make_repr(self, {
-            'image_wrappers': image_wrappers,
-            'use_physical_size_scaling': use_physical_size_scaling,
+            **args,
             **kwargs
         })
         self.image_wrappers = image_wrappers

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -127,6 +127,18 @@ class AbstractWrapper:
         """
         raise NotImplementedError("Auto view configuration has not yet been implemented for this data object wrapper class.")
 
+
+def _make_repr(obj, args):
+    """
+    >>> _make_repr(Exception(), {'answer': 42})
+    'Exception(answer=42)'
+
+    """
+    obj_name = obj.__class__.__name__
+    params = ', '.join([f'{k}={repr(v)}' for k, v in args.items()])
+    return f'{obj_name}({params})'
+
+
 class MultiImageWrapper(AbstractWrapper):
     """
     Wrap multiple imaging datasets by creating an instance of the ``MultiImageWrapper`` class.
@@ -136,8 +148,16 @@ class MultiImageWrapper(AbstractWrapper):
     """
     def __init__(self, image_wrappers, use_physical_size_scaling=False, **kwargs):
         super().__init__(**kwargs)
+        self.repr = _make_repr(self, {
+            'image_wrappers': image_wrappers,
+            'use_physical_size_scaling': use_physical_size_scaling,
+            **kwargs
+        })
         self.image_wrappers = image_wrappers
         self.use_physical_size_scaling = use_physical_size_scaling
+
+    def __repr__(self):
+        return self.repr
     
     def convert_and_save(self, dataset_uid, obj_i):
         for image in self.image_wrappers:


### PR DESCRIPTION
I need to get a working environment before going much further (#64, #65), but wanted to sound out this approach. The [higher level goal](https://github.com/hubmapconsortium/portal-ui/pull/1877/files#diff-dd2fbe2b8309793c09f6b71a272310f0c8162df7b810882ef8ee469bd67e3378R160-R161) is to just output calls to the Wrapper constructors for the values of the notebook cells, preferably the outermost Wrapper, and it will recurse to generate the string.

`repr` is in general _not_ how you should do data serialization... but that's not we're doing: We want to explain what an object is (which _is_ a good use for `repr`)... and incidentally, it should be executable.

In the one example I looked at in portal-ui, it didn't seem that the Wrapper instance was modified after creation... but I'm not confident that that's generally true.

Filing this as draft. If this doesn't seem horrible, I'd like to 
- get my environment working, 
- turn on doctests in this repo,
- and add code like this to the other Wrapper classes.

