### PR TITLE
Upgrade Vitessce to v1.1.10

### DIFF
--- a/docs/notebooks/widget_imaging_segmentation.ipynb
+++ b/docs/notebooks/widget_imaging_segmentation.ipynb
@@ -13,8 +13,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Visualization of Multi-Modal Imaging Data\n",
-    "We visualize IMS, PAS, and AF imaging data overlaid from the Spraggins Lab of the Biomolecular Multimodal Imaging Center (BIOMC) at Vanderbilt University, uploaded to the HuBMAP data portal."
+    "# Visualization of Segmentation Bitmask\n",
+    "We visualize raw imaging data + a segmentation bitmask the [MCMicro piplene](https://mcmicro.org/) - see https://www.biorxiv.org/content/10.1101/2021.03.15.435473v1.full and specifically [Figure S1](https://www.google.com/url?q=https://www.biorxiv.org/content/10.1101/2021.03.15.435473v1.full%23F3&sa=D&source=editors&ust=1623173627976000&usg=AOvVaw3JkzCxYyE86q8jxfNCgShh)"
    ]
   },
   {
@@ -38,7 +38,7 @@
    "metadata": {},
    "source": [
     "## 1. Configure Vitessce\n",
-    "Set up the images from the three different assays, with the `use_physical_size_scaling` set to `True` so that the IMS image scales to the other images based on their physical sizes."
+    "Set up the two images, already pyramidal from the [bioformats2raw + raw2ometiff pipeline](https://github.com/hms-dbmi/viv/tree/master/tutorial), labeling the segmentation \"on top\" as the bitmask and the other as simply the image data. "
    ]
   },
   {
@@ -47,16 +47,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vc = VitessceConfig(name='Spraggins Multi-Modal', description='PAS + IMS + AF From https://portal.hubmapconsortium.org/browse/collection/6a6efd0c1a2681dc7d2faab8e4ab0bca')\n",
-    "dataset = vc.add_dataset(name='Spraggins').add_object(\n",
+    "vc = VitessceConfig(name='MCMicro Bitmask Visualization', description='Segmentation + Data of Exemplar 001')\n",
+    "dataset = vc.add_dataset(name='MCMicro').add_object(\n",
     "    MultiImageWrapper(\n",
     "        image_wrappers=[\n",
-    "            OmeTiffWrapper(img_url='https://assets.hubmapconsortium.org/f4188a148e4c759092d19369d310883b/ometiff-pyramids/processedMicroscopy/VAN0006-LK-2-85-PAS_images/VAN0006-LK-2-85-PAS_registered.ome.tif?token=', name='PAS'),\n",
-    "            OmeTiffWrapper(img_url='https://assets.hubmapconsortium.org/2130d5f91ce61d7157a42c0497b06de8/ometiff-pyramids/processedMicroscopy/VAN0006-LK-2-85-AF_preIMS_images/VAN0006-LK-2-85-AF_preIMS_registered.ome.tif?token=', name='AF'),\n",
-    "            OmeTiffWrapper(img_url='https://assets.hubmapconsortium.org/be503a021ed910c0918842e318e6efa2/ometiff-pyramids/ometiffs/VAN0006-LK-2-85-IMS_PosMode_multilayer.ome.tif?token=', name='IMS Pos Mode'),\n",
-    "            OmeTiffWrapper(img_url='https://assets.hubmapconsortium.org/ca886a630b2038997a4cfbbf4abfd283/ometiff-pyramids/ometiffs/VAN0006-LK-2-85-IMS_NegMode_multilayer.ome.tif?token=', name='IMS Neg Mode')\n",
-    "        ],\n",
-    "        use_physical_size_scaling=True,\n",
+    "            OmeTiffWrapper(img_url='https://vitessce-demo-data.storage.googleapis.com/exemplar-001/exemplar-001.pyramid.ome.tif', name='Image'),\n",
+    "            OmeTiffWrapper(img_url='https://vitessce-demo-data.storage.googleapis.com/exemplar-001/cellMask.pyramid.ome.tif', name='Mask', is_bitmask=True),\n",
+    "        ]\n",
     " )\n",
     ")\n",
     "spatial = vc.add_view(dataset, cm.SPATIAL)\n",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -2660,74 +2660,74 @@
       }
     },
     "@luma.gl/constants": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.4.4.tgz",
-      "integrity": "sha512-4e58QW6UKXkxiIvWSLoAnTc4cT8nvb0PhLzu1h8KiCuaDT5Vq8csOymcNOy/jhpfcIhHlmT1KwowF5m/DcOlKg=="
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.4.5.tgz",
+      "integrity": "sha512-TKQJ/sktJ8KHS18hnY30EiLIeTfKo0bc7ECNpUrEWQdls9nZRC5mF+JDSfPv1JlDFWvNXwXR0k3D2X8J/tg3VA=="
     },
     "@luma.gl/core": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-8.4.4.tgz",
-      "integrity": "sha512-rK69iWEr8BmFbrmknkBg6IhFgcByaAm/z9qKnsRsEeomZXF5F7to/m7/RdvrsmpYVDkmWNDkqg1tiOGh55iaLQ==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-8.4.5.tgz",
+      "integrity": "sha512-J5fc35Bo8OpFTLQpeacYRtprjIMbgxNlPddnHLzBT3Q2pBrO4yHaA9NEZHEoXULUcuIgIpI/tSk62fc/bFrjiA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.4.4",
-        "@luma.gl/engine": "8.4.4",
-        "@luma.gl/gltools": "8.4.4",
-        "@luma.gl/shadertools": "8.4.4",
-        "@luma.gl/webgl": "8.4.4"
+        "@luma.gl/constants": "8.4.5",
+        "@luma.gl/engine": "8.4.5",
+        "@luma.gl/gltools": "8.4.5",
+        "@luma.gl/shadertools": "8.4.5",
+        "@luma.gl/webgl": "8.4.5"
       }
     },
     "@luma.gl/engine": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-8.4.4.tgz",
-      "integrity": "sha512-QOXCaL++cESH0+ebK77MbGDOAmJhsV2iO0Dyf4qhoDBk+8fjvB5ZnzIpv41ccTyOmPJAvmyP+kqFZRfxZKPjGw==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-8.4.5.tgz",
+      "integrity": "sha512-PhQ66ty8cww1pyJOFHv/jdaoIRKHeFgTPm1QMJ8w3iG9fkfjXN7yzzoZ3AvkkwXI4zdmC01kODMOMSgOjmJyGQ==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.4.4",
-        "@luma.gl/gltools": "8.4.4",
-        "@luma.gl/shadertools": "8.4.4",
-        "@luma.gl/webgl": "8.4.4",
+        "@luma.gl/constants": "8.4.5",
+        "@luma.gl/gltools": "8.4.5",
+        "@luma.gl/shadertools": "8.4.5",
+        "@luma.gl/webgl": "8.4.5",
         "@math.gl/core": "^3.4.2",
         "probe.gl": "^3.2.1"
       }
     },
     "@luma.gl/experimental": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/@luma.gl/experimental/-/experimental-8.4.4.tgz",
-      "integrity": "sha512-W446snQaY/H0XC8MnbgWPeRy9CBiRZWZQhZC7HzBx9FfNX313KO2vxlW5zzPT+uIbiNxHUd03WH0iXbK4jOooQ==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/@luma.gl/experimental/-/experimental-8.4.5.tgz",
+      "integrity": "sha512-SZuz6P+Oxz0SpJhfgueo6PT8JilOBAPd6KtfqUG5J8t+ZUAbpTG65O7rY+dja5gMhTyyNuNgTwzKgvjXvEMiVQ==",
       "requires": {
-        "@luma.gl/constants": "8.4.4",
+        "@luma.gl/constants": "8.4.5",
         "@math.gl/core": "^3.4.1",
         "earcut": "^2.0.6"
       }
     },
     "@luma.gl/gltools": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/@luma.gl/gltools/-/gltools-8.4.4.tgz",
-      "integrity": "sha512-OD7jcDcfAeZSxmRF9Lq15RqKDghqKeVfWOGhiTkhUdF3N4dPnW3LS/+LkGEKse6AtbHlSijo8wf6WzceXNXsLQ==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/@luma.gl/gltools/-/gltools-8.4.5.tgz",
+      "integrity": "sha512-uFmFLFOLUBTMcLC3R5zgDjE1AlytIZA7gv521zla3zNJNnzI/XJ2v56XwIDBjNiwZDPSBKEdT5xOUrCf6qcGaA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.4.4",
+        "@luma.gl/constants": "8.4.5",
         "probe.gl": "^3.2.1"
       }
     },
     "@luma.gl/shadertools": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-8.4.4.tgz",
-      "integrity": "sha512-6UGmhGlGlMWuCG6jG3ohKdBX6wXPTYr/QPYPAKwUxiVO4fFsWW3yzuZFmVJtQ6w3qFm3iMugdeulyZwvy1hZZg==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-8.4.5.tgz",
+      "integrity": "sha512-XToDDXRfzI3mqcPu36sSABq5AOHXDUHndckNnDlaDMrIpKMzJaqe4RqEL2/j/kuv85ssctTQLl/BmhrGJ/ij8g==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "@math.gl/core": "^3.4.2"
       }
     },
     "@luma.gl/webgl": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-8.4.4.tgz",
-      "integrity": "sha512-Y1LCVdE+aNox3i7lMFdDk/Fehgma5RwHZn7ajpIXLalnuuQ9bsCdXCFoRPnx2rbhzmw77jIqGpmuV/+sPNOpNw==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-8.4.5.tgz",
+      "integrity": "sha512-U01W8ElqydtAO3Efcp8TfTbIPMZrCIW9X0fgV+teAaPg3OHqqm21GtHaiQXtURCW0q2ACfI83cUaYK7tHFGKUw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.4.4",
-        "@luma.gl/gltools": "8.4.4",
+        "@luma.gl/constants": "8.4.5",
+        "@luma.gl/gltools": "8.4.5",
         "probe.gl": "^3.2.1"
       }
     },
@@ -3083,9 +3083,9 @@
       }
     },
     "@math.gl/core": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.4.2.tgz",
-      "integrity": "sha512-65vhtokCDq0N16DLwWZhPTNAGuVtTjyyi5tx950yNN3ei5BRxz2JHe6JTSnjjKO/2w9KuQYOOqokc7ARog0vKg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.4.3.tgz",
+      "integrity": "sha512-gWAuVkNi8cS4+ejZnhkMjTcKHFSYUSCTSXyCY3ReLIOknyy1QEucecOCyl3xpubRwCzPgCOiQ0yFvEdIFPpH6Q==",
       "requires": {
         "@babel/runtime": "^7.12.0",
         "gl-matrix": "^3.0.0"
@@ -3102,12 +3102,12 @@
       }
     },
     "@math.gl/culling": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@math.gl/culling/-/culling-3.4.2.tgz",
-      "integrity": "sha512-rjDfJp58jvTzMjX954/EMdcaVrX8UkkkXWXc1PU2+XFyAtaBYHDk7jiaFQQbBx8sqk9PKd62j3UTwtSreWyoyQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/culling/-/culling-3.4.3.tgz",
+      "integrity": "sha512-110pCxuzu3IUMaYFeiKVvVB/NMMkNXTph2x8U5FFOUgyDbLqKKH/l1ZRoK9JyZ5qbYJZzYr6v++bxcnc5uHOIg==",
       "requires": {
         "@babel/runtime": "^7.12.0",
-        "@math.gl/core": "3.4.2",
+        "@math.gl/core": "3.4.3",
         "gl-matrix": "^3.0.0"
       },
       "dependencies": {
@@ -3122,12 +3122,12 @@
       }
     },
     "@math.gl/geospatial": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@math.gl/geospatial/-/geospatial-3.4.2.tgz",
-      "integrity": "sha512-EiCwU3B4ftrUsPPHmLqJuxo37Y7Fvi9Mqpvxj6PvdvsF8EmEvMdYgiQXSNL9vSq5JbEy9xWL2ph47wvkWFoWUQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/geospatial/-/geospatial-3.4.3.tgz",
+      "integrity": "sha512-5IG85T0WkjxQD8xumcxQypWCw6OscvCAh7IH7E3G6P6r5et2UYUPXFtjXI1ZIdUS/SjD3Jd9Sr4ZKeVSAigt6w==",
       "requires": {
         "@babel/runtime": "^7.12.0",
-        "@math.gl/core": "3.4.2",
+        "@math.gl/core": "3.4.3",
         "gl-matrix": "^3.0.0"
       },
       "dependencies": {
@@ -3142,17 +3142,17 @@
       }
     },
     "@math.gl/polygon": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.4.2.tgz",
-      "integrity": "sha512-ANbZmcrzavzEe0bHbdEYyiudPdGGV/quB3FxUJa3L1QCcZbnrqvnuwqX+8U8ltIDhbACG1x0Uxefwo8p77aMNw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.4.3.tgz",
+      "integrity": "sha512-ZhccVGn0PgwsN/SNT1jlPPOydkY8bW0YDDWOK4eH70zypLVYSorAyxWEwefqBjZxCkgbQU3WnpxHNSMLr+jVCQ==",
       "requires": {
-        "@math.gl/core": "3.4.2"
+        "@math.gl/core": "3.4.3"
       }
     },
     "@math.gl/web-mercator": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.4.2.tgz",
-      "integrity": "sha512-Az/WI8vxbqnrTEcYgqDQ3CgCRoFA2a4XT9mkjVrT7iIlfrUF5lrIXcmpljjKvoFNBldKrng7hFSeHHM2ghgSrg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.4.3.tgz",
+      "integrity": "sha512-wfT1ku2b0k9MmaesFev60PXCCqqDvCR9batcY99ob/nMRXcQ/F5yVChS07OIqjUJseK6+6Gep9iYXiflPyPR2Q==",
       "requires": {
         "@babel/runtime": "^7.12.0",
         "gl-matrix": "^3.0.0"
@@ -3774,9 +3774,12 @@
       "dev": true
     },
     "@types/fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-IyNhGHu71jH1jCXTHmafuoAAdsbBON3kDh7u/UUhLmjYgN5TYB54e1R8ckTCiIevl2UuZaCsi9XRxineY5yUjw==",
+      "requires": {
+        "fast-json-stable-stringify": "*"
+      }
     },
     "@types/glob": {
       "version": "7.1.3",
@@ -3836,9 +3839,9 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.5.tgz",
-      "integrity": "sha512-bj4biDB9ZJmGAYTWSKJly6bMr4BLUiBrx9ujiJEoP9XIDY9CTaPGxE5QWN/1WjpPLzYF7/jRNnV2nNxNe970sw==",
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.9.tgz",
+      "integrity": "sha512-2Cw7FvevpJxQrCb+k5t6GH1KIvmadj5uBbjPaLlJB/nZWUj56e1ZqcD6zsoMFB47MsJUTFl9RJ132A7hb3QFJA==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -4158,6 +4161,13 @@
         "prop-types": "^15.7.2",
         "prop-types-exact": "^1.2.0",
         "react-is": "^16.13.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
       }
     },
     "ajv": {
@@ -4667,12 +4677,12 @@
       }
     },
     "broadcast-channel": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.5.3.tgz",
-      "integrity": "sha512-OLOXfwReZa2AAAh9yOUyiALB3YxBe0QpThwwuyRHLgpl8bSznSDmV6Mz7LeBJg1VZsMcDcNMy7B53w12qHrIhQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.6.0.tgz",
+      "integrity": "sha512-0x87tKJULniTOfECZP/LCsqWyMEbz0Oa+4yJ4i5dosOMxWUjx6mZ6nt9QmD2ox0r3MaCPojHrTQ2dj4ASZupeA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.0.4",
+        "detect-node": "^2.1.0",
         "js-sha3": "0.8.0",
         "microseconds": "0.2.0",
         "nano-time": "1.0.0",
@@ -5246,9 +5256,9 @@
       "dev": true
     },
     "complex.js": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.12.tgz",
-      "integrity": "sha512-oQX99fwL6LrTVg82gDY1dIWXy6qZRnRL35N+YhIX0N7tSwsa0KFy6IEMHTNuCW4mP7FS7MEqZ/2I/afzYwPldw=="
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.13.tgz",
+      "integrity": "sha512-UEWd3G3/kd3lJmsdLsDh9qfinJlujL4hIFn3Vo4/G5eqehPsgCHf2CLhFs77tVkOp2stt/jbNit7Q1XFANFltA=="
     },
     "component-classes": {
       "version": "1.2.6",
@@ -6059,9 +6069,9 @@
       "dev": true
     },
     "detect-node": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.5.tgz",
-      "integrity": "sha512-qi86tE6hRcFHy8jI1m2VG+LaPUR1LhqDa5G8tVjuUXmOrpuAgqsA1pN0+ldgr3aKUH+QLI9hCY/OcRYisERejw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "detect-port-alt": {
       "version": "1.1.6",
@@ -6103,9 +6113,9 @@
       }
     },
     "dom-align": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.1.tgz",
-      "integrity": "sha512-CdTD9EdA5WviP8oO3n+okOm0Xt7dSuWxRTLcJiW0memwUr3Tvz66JDDCh9cb50IZFHXvBmLoyX454uJU/EVg+g=="
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.2.tgz",
+      "integrity": "sha512-pHuazgqrsTFrGU2WLDdXxCFabkdQDx72ddkraZNih1KsMcN5qsRSTR9O4VJRlwTPCPb5COYg3LOfiMHHcPInHg=="
     },
     "dom-helpers": {
       "version": "5.2.1",
@@ -6355,6 +6365,11 @@
             "has-symbols": "^1.0.1",
             "object-keys": "^1.1.1"
           }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -6413,9 +6428,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+      "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -6425,14 +6440,14 @@
         "has-symbols": "^1.0.2",
         "is-callable": "^1.2.3",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.2",
-        "is-string": "^1.0.5",
-        "object-inspect": "^1.9.0",
+        "is-regex": "^1.1.3",
+        "is-string": "^1.0.6",
+        "object-inspect": "^1.10.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
         "string.prototype.trimend": "^1.0.4",
         "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.0"
+        "unbox-primitive": "^1.0.1"
       },
       "dependencies": {
         "has-symbols": {
@@ -7077,9 +7092,9 @@
       }
     },
     "fraction.js": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.13.tgz",
-      "integrity": "sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.1.tgz",
+      "integrity": "sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -7890,6 +7905,13 @@
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "requires": {
         "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
       }
     },
     "homedir-polyfill": {
@@ -8821,26 +8843,37 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "math.gl": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/math.gl/-/math.gl-3.4.2.tgz",
-      "integrity": "sha512-0I77HBiC+q/XRRw807dCwUeMTUotzNQUQZEk0kPd39iRmU67dLId0+OtCGFYjIzyM+gNaj1JWueiOYV/gdl+dQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/math.gl/-/math.gl-3.4.3.tgz",
+      "integrity": "sha512-GSX4GQUVbEQtFnQryDIJVx35WO4HP55NbnIP18/a9G7e5jbTj7QqR2pHKkdlvP5D3jDHP09o39cXMcx0YxqUSA==",
       "requires": {
-        "@math.gl/core": "3.4.2"
+        "@math.gl/core": "3.4.3"
       }
     },
     "mathjs": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-9.3.2.tgz",
-      "integrity": "sha512-0YKSKAeN9OkbIQrxfxnBT4kk/KlH71piWOsvVvAasyRIj/Xd/zlpc5VP/aFxwr+llOq2F3f6booPEu2fWv3yjQ==",
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-9.4.2.tgz",
+      "integrity": "sha512-xu0AU6bpjxbDgCB824s/yDpAe0KR1TMUYz/yY7rYyRcEH56OuG8JPgxJhqlUyhhRpY++ZFDnRxRNGChYx1FLKQ==",
       "requires": {
-        "complex.js": "^2.0.11",
+        "@babel/runtime": "^7.14.0",
+        "complex.js": "^2.0.13",
         "decimal.js": "^10.2.1",
         "escape-latex": "^1.2.0",
-        "fraction.js": "^4.0.13",
+        "fraction.js": "^4.1.1",
         "javascript-natural-sort": "^0.7.1",
         "seedrandom": "^3.0.5",
         "tiny-emitter": "^2.1.0",
         "typed-function": "^2.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "md5.js": {
@@ -9139,9 +9172,9 @@
       }
     },
     "mjolnir.js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-2.5.0.tgz",
-      "integrity": "sha512-YkVoyKs7qm9xvAgRgjx3Md/7eYqmq7VXOgTKQNnmuzcBJzMebjdIWa7FdTd0RZBrw3UL6V6TTktsxJwBMLXUNA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-2.5.1.tgz",
+      "integrity": "sha512-nwqN1llv2i9V4hfwcbxk2ZywG5ViCqhaoHrotRJgxyd2mI1GXDQ3/L2NBkoyX/w+bpcw3LvrYHzPQIN/7LNocQ==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "hammerjs": "^2.0.8"
@@ -9459,14 +9492,13 @@
       }
     },
     "object.entries": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
-      "integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
+      "integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
-        "has": "^1.0.3"
+        "es-abstract": "^1.18.2"
       }
     },
     "object.fromentries": {
@@ -9490,20 +9522,19 @@
       }
     },
     "object.values": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-      "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+      "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2",
-        "has": "^1.0.3"
+        "es-abstract": "^1.18.2"
       }
     },
     "observable-fns": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.5.1.tgz",
-      "integrity": "sha512-wf7g4Jpo1Wt2KIqZKLGeiuLOEMqpaOZ5gJn7DmSdqXgTdxRwSdBhWegQQpPteQ2gZvzCKqNNpwb853wcpA0j7A=="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
+      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
     },
     "once": {
       "version": "1.4.0",
@@ -10060,6 +10091,13 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
       }
     },
     "prop-types-exact": {
@@ -10081,6 +10119,11 @@
         "warning": "^4.0.0"
       },
       "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
         "warning": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -10399,6 +10442,11 @@
             "react-lifecycles-compat": "^3.0.4",
             "shallowequal": "^1.1.0"
           }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -10448,6 +10496,11 @@
             "shallowequal": "^1.1.0"
           }
         },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
         "warning": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -10472,9 +10525,9 @@
       }
     },
     "rc-util": {
-      "version": "5.12.2",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.12.2.tgz",
-      "integrity": "sha512-kzqG2lHY4oZsoj5Svov12K+9wi0xQHvGzfbLlsF1PDEH1aTbgdNTwlE7mejc3MGEr+7bNHa4+T5ZemCS8vQ1Gw==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.13.1.tgz",
+      "integrity": "sha512-Dws2tjXBBihfjVQFlG5JzZ/5O3Wutctm0W94Wb1+M7GD2roWJPrQdSa4AkWm2pn0Ms32zoVPPkWodFeAYZPLfA==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "react-is": "^16.12.0",
@@ -10488,6 +10541,11 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -10838,15 +10896,15 @@
       "dev": true
     },
     "react-grid-layout": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.2.4.tgz",
-      "integrity": "sha512-AWorwRmkEyOPWF516BDbEhMjGhTCPf6zALQ3HIYrJdRmbbj1n5PDPNEI1eI818zhB07KwGVtF0WBxq2CmA2CNA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.2.5.tgz",
+      "integrity": "sha512-P/NNWAExTX/zEq+RUh6hrIG67UBicDNCOOg9LZe8BAtSdYtCnCGgVmWBS+sIbM0C8RJIiyGsFHh5dIfCddhS/w==",
       "requires": {
-        "classnames": "2.x",
+        "classnames": "2.3.1",
         "lodash.isequal": "^4.0.0",
         "prop-types": "^15.0.0",
         "react-draggable": "^4.0.0",
-        "react-resizable": "^1.10.0"
+        "react-resizable": "^3.0.1"
       },
       "dependencies": {
         "react-draggable": {
@@ -10857,13 +10915,22 @@
             "classnames": "^2.2.5",
             "prop-types": "^15.6.0"
           }
+        },
+        "react-resizable": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.0.1.tgz",
+          "integrity": "sha512-wban8GguvXrmeObSVTmhxs99G9eUgYSGugf0i32qHXyqKDTzQsCKLhm3VJW24TpTBKJvM+cybNExskOCYkYF5Q==",
+          "requires": {
+            "prop-types": "15.x",
+            "react-draggable": "^4.0.3"
+          }
         }
       }
     },
     "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -10956,12 +11023,19 @@
         "prop-types": "^15.6.2",
         "react-is": "^16.8.6",
         "scheduler": "^0.19.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
       }
     },
     "react-transition-group": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
-      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
+      "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -10980,9 +11054,9 @@
       },
       "dependencies": {
         "@types/react": {
-          "version": "16.14.6",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.6.tgz",
-          "integrity": "sha512-Ol/aFKune+P0FSFKIgf+XbhGzYGyz0p7g5befSt4rmbzfGLaZR0q7jPew9k7d3bvrcuaL8dPy9Oz3XGZmf9n+w==",
+          "version": "16.14.8",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.8.tgz",
+          "integrity": "sha512-QN0/Qhmx+l4moe7WJuTxNiTsjBwlBGHqKGvInSQCBdo7Qio0VtOqwsC0Wq7q3PbJlB0cR4Y4CVo1OOe6BOsOmA==",
           "requires": {
             "@types/prop-types": "*",
             "@types/scheduler": "*",
@@ -12368,14 +12442,14 @@
       "dev": true
     },
     "threads": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.4.tgz",
-      "integrity": "sha512-A+9MQFAUha9W8MjIPmrvETy98qVmZFr5Unox9D95y7kvz3fBpGiFS7JOZs07B2KvTHoRNI5MrGudRVeCmv4Alw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.5.tgz",
+      "integrity": "sha512-yL1NN4qZ25crW8wDoGn7TqbENJ69w3zCEjIGXpbqmQ4I+QHrG8+DLaZVKoX74OQUXWCI2lbbrUxDxAbr1xjDGQ==",
       "requires": {
         "callsites": "^3.1.0",
         "debug": "^4.2.0",
         "is-observable": "^2.1.0",
-        "observable-fns": "^0.5.1",
+        "observable-fns": "^0.6.1",
         "tiny-worker": ">= 2"
       },
       "dependencies": {
@@ -12542,9 +12616,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -13004,14 +13078,15 @@
       }
     },
     "vega-embed": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.17.0.tgz",
-      "integrity": "sha512-9eiVZCrLDb/EiVCMbMYouWB/q9dOeVkL5Bh0vU6wsUpIV/bbEvS47uljuo3YSxFqkfNpJ+Qt8xvLRiYSnN4lqw==",
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.18.2.tgz",
+      "integrity": "sha512-wcDyQPE4J5aiCDc3/suH5RQDvrKkjuLkhzUcbOLwEkNF8/+pp17tS0JghzEvAPNRg+5aG1/N2ydixq8Lk3dOlg==",
       "requires": {
         "fast-json-patch": "^3.0.0-1",
         "json-stringify-pretty-compact": "^3.0.0",
         "semver": "^7.3.5",
-        "vega-schema-url-parser": "^2.1.0",
+        "tslib": "^2.2.0",
+        "vega-schema-url-parser": "^2.2.0",
         "vega-themes": "^2.10.0",
         "vega-tooltip": "^0.25.1"
       },
@@ -13242,6 +13317,11 @@
           "requires": {
             "ansi-regex": "^5.0.0"
           }
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
         },
         "vega-expression": {
           "version": "3.0.1",
@@ -13520,17 +13600,17 @@
       }
     },
     "viewport-mercator-project": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/viewport-mercator-project/-/viewport-mercator-project-7.0.2.tgz",
-      "integrity": "sha512-gH0pBO4Y5McGCPaKulkpL9MPDg+wtOSXtndwh0467T/WLMerfBi7EkHYw1pp9HE2VeqFqUaAfot98cQPGaIjEA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/viewport-mercator-project/-/viewport-mercator-project-7.0.3.tgz",
+      "integrity": "sha512-5nSgVK8jKTSKzOvsa8TSSd2IeQCpHfSNiBOOOMQLvzlxgWD0YoF4xRmyZio3GaLtKSE+50UB892X3R1SAMbaww==",
       "requires": {
-        "@math.gl/web-mercator": "^3.2.0"
+        "@math.gl/web-mercator": "^3.4.3"
       }
     },
     "vitessce": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-1.1.9.tgz",
-      "integrity": "sha512-b1I6aA4Ab41G2Ra7Ebt2AG/csEWTlFzCobs21VAjNE4p1DGr87ZHid5e82FVJN80N4ENsAy7ycwTIuqxiNe2MQ==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-1.1.10.tgz",
+      "integrity": "sha512-XDqUpDkOEkLcIMjpOc4ldXiW1zJJGRO0Hya1S0j9/pmej1cp3e/0cZLWzM6Tpz3i4eReY4YXejrhxzAs6r9DBw==",
       "requires": {
         "@hms-dbmi/viv": "^0.9.4",
         "@loaders.gl/3d-tiles": "^2.3.0",
@@ -14205,9 +14285,9 @@
       }
     },
     "zustand": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.5.1.tgz",
-      "integrity": "sha512-7J56Ve814z4zap71iaKFD+t65LFI//jEq/Vf55BTSVqJZCm+w9rov8OMBg+YSwIPQk54bfoIWHTrOWuAbpEDMw=="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.5.2.tgz",
+      "integrity": "sha512-HUCQI9O77/D/zvoWPNv4dwLriiiY2xtEqnQ0TVY8uaPjmOHls04Okd0w3sWUE9Ex2LaYlSk11DbPPIOZ6shEWg=="
     }
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -44,7 +44,7 @@
     "pubsub-js": "^1.9.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "vitessce": "^1.1.9"
+    "vitessce": "^1.1.10"
   },
   "jupyterlab": {
     "extension": "dist/labplugin",

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -54,6 +54,7 @@ class TestWrappers(unittest.TestCase):
                         'type': 'ome-tiff',
                         'url': 'http://localhost:8000/A/0/test.ome.tif',
                         'metadata': {
+                            'isBitmask': False,
                             'omeTiffOffsetsUrl': 'http://localhost:8000/A/0/test.offsets.json'
                         }
                     }

--- a/vitessce/_version.py
+++ b/vitessce/_version.py
@@ -1,5 +1,5 @@
 # Module version
-version_info = (0, 1, 0, 'alpha', 10)
+version_info = (0, 1, 0, 'alpha', 11)
 
 # Module version stage suffix map
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -186,13 +186,17 @@ class OmeTiffWrapper(AbstractWrapper):
     Wrap an OME-TIFF File by creating an instance of the ``OmeTiffWrapper`` class.
 
     :param str img_path: A local filepath to an OME-TIFF file.
+    :param str offsets_path: A local filepath to an offsets.json file.
     :param str img_url: A remote URL of an OME-TIFF file.
+    :param str offsets_url: A remote URL of an offsets.json file.
     :param str name: The display name for this OME-TIFF within Vitessce.
     :param list[number] transformation_matrix: A column-major ordered matrix for transforming this image (see http://www.opengl-tutorial.org/beginners-tutorials/tutorial-3-matrices/#homogeneous-coordinates for more information).
+    :param bool is_bitmask: Whether or not this image is a bitmask.
     :param \\*\\*kwargs: Keyword arguments inherited from :class:`~vitessce.wrappers.AbstractWrapper`
     """
 
-    def __init__(self, img_path=None, offsets_path=None, img_url=None, offsets_url=None, name="", transformation_matrix=None, **kwargs):
+    def __init__(self, img_path=None, offsets_path=None, img_url=None, offsets_url=None, name="", transformation_matrix=None, is_bitmask=False,
+     **kwargs):
         super().__init__(**kwargs)
         self.name = name
         self._img_path = img_path
@@ -200,6 +204,7 @@ class OmeTiffWrapper(AbstractWrapper):
         self._offsets_url = offsets_url
         self._transformation_matrix = transformation_matrix
         self.is_remote = img_url is not None
+        self.is_bitmask = is_bitmask
         if img_url is not None and (img_path is not None or offsets_path is not None):
             raise ValueError("Did not expect img_path or offsets_path to be provided with img_url")
     
@@ -259,6 +264,7 @@ class OmeTiffWrapper(AbstractWrapper):
             metadata["transform"] = {
                 "matrix": self._transformation_matrix
             }
+        metadata["isBitmask"] = self.is_bitmask
         # Only attach metadata if there is some - otherwise schema validation fails.
         if len(metadata.keys()) > 0:
             image["metadata"] = metadata


### PR DESCRIPTION
This PR:
- Adds the bitmask option to our Python API
- Fix some small documentation issues
- Add the other IMS image to the remote imaging notebook
- Make a bitmask notebook (we can delete this if you want @keller-mark it was mostly for my testing but figured I'd leave it in if we want to use it)
- Bumps the version of this package for release