### PR TITLE
Added web_app method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 
-## [0.1.1] (In Progress)
+## [0.1.0a13] (In Progress)
+
+### Added
+- Added a `VitessceConfig.web_app()` method for launching the `vitessce.io` web application based on the current config object, and serving the data associated with the config via the Starlette server.
+
+### Changed
+
+## [0.1.0a12]
 
 ### Added
 - Added a `VitessceConfig.widget()` method for convenience when creating the widget (no more need to import a separate `VitessceWidget` class).

--- a/docs/notebooks/web_app_brain.ipynb
+++ b/docs/notebooks/web_app_brain.ipynb
@@ -1,0 +1,260 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "# Vitessce Web App Tutorial"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visualization of single-cell RNA seq data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Import dependencies\n",
+    "\n",
+    "We need to import the classes and functions that we will be using from the corresponding packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from os.path import join\n",
+    "from urllib.request import urlretrieve\n",
+    "from anndata import read_h5ad\n",
+    "import scanpy as sc\n",
+    "\n",
+    "from vitessce import (\n",
+    "    VitessceConfig,\n",
+    "    Component as cm,\n",
+    "    CoordinationType as ct,\n",
+    "    AnnDataWrapper,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Download the data\n",
+    "\n",
+    "For this example, we need to download a dataset from the COVID-19 Cell Atlas https://www.covid19cellatlas.org/index.healthy.html#habib17."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.makedirs(\"data\", exist_ok=True)\n",
+    "adata_filepath = join(\"data\", \"habib17.processed.h5ad\")\n",
+    "urlretrieve('https://covid19.cog.sanger.ac.uk/habib17.processed.h5ad', adata_filepath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Load the data\n",
+    "\n",
+    "Note: this function may print a `FutureWarning`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata = read_h5ad(adata_filepath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3.1. Preprocess the Data For Visualization\n",
+    "\n",
+    "This dataset contains 25,587 genes.  In order to visualize it efficiently, we convert it to CSC sparse format so that we can make fast requests for gene data.  We also prepare to visualize the top 50 highly variable genes for the heatmap as ranked by dispersion norm, although one may use any boolean array filter for the heatmap."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "top_dispersion = adata.var[\"dispersions_norm\"][\n",
+    "    sorted(\n",
+    "        range(len(adata.var[\"dispersions_norm\"])),\n",
+    "        key=lambda k: adata.var[\"dispersions_norm\"][k],\n",
+    "    )[-51:][0]\n",
+    "]\n",
+    "adata.var[\"top_highly_variable\"] = (\n",
+    "    adata.var[\"dispersions_norm\"] > top_dispersion\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Create the Vitessce widget configuration\n",
+    "\n",
+    "Vitessce needs to know which pieces of data we are interested in visualizing, the visualization types we would like to use, and how we want to coordinate (or link) the views."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.1. Instantiate a `VitessceConfig` object\n",
+    "\n",
+    "Use the `VitessceConfig(name, description)` constructor to create an instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vc = VitessceConfig(name='Habib et al', description='COVID-19 Healthy Donor Brain')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.2. Add a dataset to the `VitessceConfig` instance\n",
+    "\n",
+    "In Vitessce, a dataset is a container for one file per data type. The `.add_dataset(name)` method on the `vc` instance sets up and returns a new dataset instance.\n",
+    "\n",
+    "Then, we can call the dataset's `.add_object(wrapper_object)` method to attach a \"data wrapper\" instance to our new dataset. For example, the `AnnDataWrapper` class knows how to convert AnnData objects to the corresponding Vitessce data types.\n",
+    "\n",
+    "Dataset wrapper classes may require additional parameters to resolve ambiguities. For instance, `AnnData` objects may store multiple clusterings or cell type annotation columns in the `adata.obs` dataframe. We can use the parameter `cell_set_obs_cols` to tell Vitessce which columns of the `obs` dataframe correspond to cell sets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = vc.add_dataset(name='Brain').add_object(AnnDataWrapper(\n",
+    "        adata,\n",
+    "        mappings_obsm=[\"X_umap\"],\n",
+    "        mappings_obsm_names=[\"UMAP\"],\n",
+    "        cell_set_obs=[\"CellType\"],\n",
+    "        cell_set_obs_names=[\"Cell Type\"],\n",
+    "        expression_matrix=\"X\",\n",
+    "        matrix_gene_var_filter=\"top_highly_variable\"\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.3. Add visualizations to the `VitessceConfig` instance\n",
+    "\n",
+    "Now that we have added a dataset, we can configure visualizations. The `.add_view(dataset, component_type)` method adds a view (i.e. visualization or controller component) to the configuration.\n",
+    "\n",
+    "The `Component` enum class (which we have imported as `cm` here) can be used to fill in the `component_type` parameter.\n",
+    "\n",
+    "For convenience, the `SCATTERPLOT` component type takes the extra `mapping` keyword argument, which specifies which embedding should be used for mapping cells to (x,y) points on the plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scatterplot = vc.add_view(dataset, cm.SCATTERPLOT, mapping=\"UMAP\")\n",
+    "cell_sets = vc.add_view(dataset, cm.CELL_SETS)\n",
+    "genes = vc.add_view(dataset, cm.GENES)\n",
+    "heatmap = vc.add_view(dataset, cm.HEATMAP)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.4. Define the visualization layout\n",
+    "\n",
+    "The `vc.layout(view_concat)` method allows us to specify how our views will be arranged in the layout grid in the widget. The `|` and `/` characters are magic syntax for `hconcat(v1, v2)` and `vconcat(v1, v2)`, respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vc.layout((scatterplot | cell_sets) / (heatmap | genes));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Launch the web application\n",
+    "\n",
+    "The `vc.web_app()` method serves the processed data locally and opens a web browser to `http://vitessce.io/?url={config_as_json}`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vc.web_app()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -12,7 +12,10 @@ from .wrappers import (
     AnnDataWrapper,
     SnapWrapper,
 )
-from .widget import VitessceWidget
+from .widget import (
+    VitessceWidget,
+    launch_vitessce_io,
+)
 from .export import (
     export_to_s3,
     export_to_files,
@@ -767,7 +770,7 @@ class VitessceConfig:
     
     def widget(self, **kwargs):
         """
-        Convenience function for instantiating a VitessceWidget object based on this config.
+        Instantiate a VitessceWidget object based on this config.
         
         :param str theme: The theme name, either "light" or "dark". By default, "auto", which selects light or dark based on operating system preferences.
         :param int height: The height of the widget, in pixels. By default, 600.
@@ -790,6 +793,32 @@ class VitessceConfig:
             vw
         """
         return VitessceWidget(self, **kwargs)
+    
+    def web_app(self, **kwargs):
+        """
+        Launch the http://vitessce.io web app using this config.
+        
+        :param str theme: The theme name, either "light" or "dark". By default, "auto", which selects light or dark based on operating system preferences.
+        :param int port: The port to use when serving data objects on localhost. By default, 8000.
+        :param base_url: If the web app is being accessed remotely (i.e. the data is being served from a remote machine), specify the base URL here. If serving and accessing the data on the same machine, keep as None to use a localhost URL. 
+        :type base_url: str or None
+        :param bool open: Should the browser be opened to the web app URL? By default, True.
+        
+        :returns: The URL of the web app (containing the Vitessce configuration as URL-encoded JSON).
+        :rtype: str
+
+        .. code-block:: python
+            :emphasize-lines: 6
+
+            from vitessce import VitessceConfig, Component as cm, CoordinationType as ct
+
+            vc = VitessceConfig()
+            my_dataset = vc.add_dataset(name='My Dataset')
+            v1 = vc.add_view(my_dataset, cm.SPATIAL)
+            vc.layout(v1)
+            vc.web_app()
+        """
+        return launch_vitessce_io(self, **kwargs)
         
     def export(self, to, *args, **kwargs):
         """


### PR DESCRIPTION
This PR adds an internal function `launch_vitessce_io` and a method `.web_app` on config instances. I factored out the shared data serving code from `VitessceWidget.__init__()` into two new internal functions `get_port_and_routes` and `serve_routes`.

The `web_app` method allows serving a config's data using the Starlette web server, but instead of rendering a widget, it creates a vitessce.io URL which includes the URLs of the served data. The new `web_app_brain.ipynb` notebook has a demo.