### PR TITLE
fix: force single chunk for labextension build

### DIFF
--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const fs = require('fs');
 const version = require('./package.json').version;
 const PnpWebpackPlugin = require('pnp-webpack-plugin');
+const webpack = require('webpack');
 
 const mode = 'development';
 process.env.NODE_ENV = mode;
@@ -147,5 +148,8 @@ module.exports = [
         externals: ['@jupyter-widgets/base'],
         resolve,
         resolveLoader,
+        plugins: [
+          new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),
+        ],
     },
 ];


### PR DESCRIPTION
Attempt to address: https://github.com/vitessce/vitessce/pull/1045#issuecomment-984753256

I really wish building lab extensions wasn't this hard... My understanding of the issue in the comment above is as follows.

Our `webpack.config.js` generates a code-split module containing `js/dist/labplugin.js` and `js/dist/1.labplugin.js` (the dynamically loaded higlass module). This is generated running `webpack` (`npm run build:nbextension`), but the `jupyter labextension build` command (`npm run build:labextension`) uses this file as input. 

`jupyter labextension build` is a bit of a black box (to me), but it seems like it only takes a single entry point (i could be wrong), which is transforms, hashes and writes the results to `vitessce/labextension/static/`. As a result, `1.labplugin.js` is missed, and I'm not aware of how to "hook" into the labextension build. My "solution" is to try to force a single chunk in our webpack config.

Ideally we could set the public path in in the webpack config to `/lab/extensions/vitessce-jupyter/static/`, but the filenames end up getting mangled anyways so whatever is in `js/dist` (and hardcoded in the entrypoint) won't be able to load.