### PR TITLE
Exclude directories from flake8 linting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,7 @@ ignore =
   # With the ignores above in place, we hit a new set of errors:
   W503, # line break before binary operator
   W504, # line break after binary operator
+exclude =
+  ./js/node_modules/,
+  ./docs/notebooks/.ipynb_checkpoints/,
+  ./build/


### PR DESCRIPTION
This PR adds a list of directories to exclude from flake8 (auto-generated ones like .ipynb_checkpoints and node_modules).

Without these excludes, the flake8 output looks like
[flake.txt](https://github.com/vitessce/vitessce-python/files/8490531/flake.txt)
 