### PR TITLE
Add build dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,4 @@
 name: vitessce-python-dev
-channels:
- - bioconda
- - conda-forge
 dependencies:
  - python==3.8
  - pip
- - pip:
-   - build==0.1.0

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,9 @@ cmdclass['jsdeps'] = combine_commands(
 
 
 extras_require = {
+    'building': [
+        'build==0.1.0',
+    ],
     'jupyter': [
         # Required for developing jupyter extensions.
         'jupyterlab==3.1.14',
@@ -81,7 +84,7 @@ extras_require = {
 extras_require['all'] = extras_require['proxy']
 
 # Option for developers to install all runtime deps + all development deps.
-extras_require['dev'] = extras_require['all'] + extras_require['jupyter'] + extras_require['testing'] + extras_require['linting'] + extras_require['docs']
+extras_require['dev'] = extras_require['all'] + extras_require['building'] + extras_require['jupyter'] + extras_require['testing'] + extras_require['linting'] + extras_require['docs']
 
 setup_args = dict(
     name=name,

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ extras_require = {
 extras_require['all'] = extras_require['proxy']
 
 # Option for developers to install all runtime deps + all development deps.
-extras_require['dev'] = extras_require['all'] + extras_require['building'] + extras_require['jupyter'] + extras_require['testing'] + extras_require['linting'] + extras_require['docs']
+extras_require['dev'] = sum(extras_require.values(), [])
 
 setup_args = dict(
     name=name,


### PR DESCRIPTION
The PR #149 did fix #148 but now has a different error: the `build` dependency was not included in the `dev` extras_require https://github.com/vitessce/vitessce-python/runs/6211731831?check_suite_focus=true