### PR TITLE
Mccalluc/try to split deps again

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
-      - run: pip install .[docs,notebook]
+      - run: pip install -e .[docs,notebook]
       - run: make html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
-      - run: pip install .[docs] .[notebook]
+      - run: pip install .[docs,notebook]
       - run: make html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
-      - run: pip install -e .[docs]
+      - run: pip install .[docs] .[notebook]
       - run: make html

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           python-version: '3.8'
       - name: Install vitessce
-        run: pip install -e .[testing]
+        run: pip install -e .[testing] .[notebook]
       - name: Run unittests
         working-directory: ./tests
         run: python -m unittest

--- a/.github/workflows/test_python_36.yml
+++ b/.github/workflows/test_python_36.yml
@@ -12,14 +12,10 @@ jobs:
         with:
           python-version: '3.6'
       - name: Install vitessce
-        run: pip install -e .
-
-      # For now, just confirm that it can be installed.
-      # 3.6 support may only be needed for the short term, so may not be worth splitting tests.
-
+        run: pip install -e .[testing]
       - name: Run unittests
         working-directory: ./tests
-        run: python -m unittest
+        run: python -m unittest test_config.py
       - name: Run doctests
         working-directory: ./vitessce
         run: pytest --doctest-modules ./config.py ./repr.py

--- a/.github/workflows/test_python_36.yml
+++ b/.github/workflows/test_python_36.yml
@@ -20,6 +20,6 @@ jobs:
       # - name: Run unittests
       #   working-directory: ./tests
       #   run: python -m unittest
-      # - name: Run doctests
-      #   working-directory: ./vitessce
-      #   run: pytest --doctest-modules
+      - name: Run doctests
+        working-directory: ./vitessce
+        run: pytest --doctest-modules ./config.py ./repr.py

--- a/.github/workflows/test_python_36.yml
+++ b/.github/workflows/test_python_36.yml
@@ -1,4 +1,4 @@
-name: Test Python 3.6
+name: Test Python 3.6 (install only)
 
 on: [push, pull_request]
 

--- a/.github/workflows/test_python_36.yml
+++ b/.github/workflows/test_python_36.yml
@@ -1,0 +1,25 @@
+name: Test Python 3.6
+
+on: [push, pull_request]
+
+jobs:
+  test_python:
+    runs-on: ubuntu-18.04
+    name: Test Python code
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+      - name: Install vitessce
+        run: pip install -e .
+
+      # For now, just confirm that it can be installed.
+      # 3.6 support may only be needed for the short term, so may not be worth splitting tests.
+
+      # - name: Run unittests
+      #   working-directory: ./tests
+      #   run: python -m unittest
+      # - name: Run doctests
+      #   working-directory: ./vitessce
+      #   run: pytest --doctest-modules

--- a/.github/workflows/test_python_36.yml
+++ b/.github/workflows/test_python_36.yml
@@ -1,4 +1,4 @@
-name: Test Python 3.6 (install only)
+name: Test Python 3.6 (partial)
 
 on: [push, pull_request]
 
@@ -17,9 +17,9 @@ jobs:
       # For now, just confirm that it can be installed.
       # 3.6 support may only be needed for the short term, so may not be worth splitting tests.
 
-      # - name: Run unittests
-      #   working-directory: ./tests
-      #   run: python -m unittest
+      - name: Run unittests
+        working-directory: ./tests
+        run: python -m unittest
       - name: Run doctests
         working-directory: ./vitessce
         run: pytest --doctest-modules ./config.py ./repr.py

--- a/.github/workflows/test_python_38.yml
+++ b/.github/workflows/test_python_38.yml
@@ -1,4 +1,4 @@
-name: Test Python
+name: Test Python 3.8
 
 on: [push, pull_request]
 

--- a/.github/workflows/test_python_38.yml
+++ b/.github/workflows/test_python_38.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           python-version: '3.8'
       - name: Install vitessce
-        run: pip install -e .[testing] .[notebook]
+        run: pip install -e .[testing,notebook]
       - name: Run unittests
         working-directory: ./tests
         run: python -m unittest

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ extras_require = {
         # Upgrading starlette will remove this dependency.
         'aiofiles>=0.6.0',
 
-        # These are used in wrapper classes, are not compatible with Python 3.6:
+        # These are used in wrapper classes, and are not compatible with Python 3.6:
         'numpy>=1.21.2',  # Last compatible version is 1.19.5
         'generate-tiff-offsets>=0.1.7',  # Last compatible version is 2020.9.3
     ]

--- a/setup.py
+++ b/setup.py
@@ -91,11 +91,14 @@ extras_require = {
         # Upgrading starlette will remove this dependency.
         'aiofiles>=0.6.0',
 
-        # These don't work in Python 3.6:
+        # These are used in wrapper classes, are not compatible with Python 3.6:
         'numpy>=1.21.2',  # Last compatible version is 1.19.5
         'generate-tiff-offsets>=0.1.7',  # Last compatible version is 2020.9.3
     ]
 }
+
+extras_require['docs'] += extras_require['notebook']
+extras_require['testing'] += extras_require['notebook']
 
 # Option for user to install all runtime deps.
 extras_require['all'] = extras_require['proxy']
@@ -115,8 +118,6 @@ setup_args = dict(
         'numcodecs>=0.5.7',
         'scipy>=1.2.1',
         'negspy>=0.2.24',
-        # 'generate-tiff-offsets>=0.1.7',
-        # 'numpy>=1.21.2',
         'pandas>=1.1.2',
         'black>=21.11b1',
     ],

--- a/setup.py
+++ b/setup.py
@@ -97,9 +97,6 @@ extras_require = {
     ]
 }
 
-extras_require['docs'] += extras_require['notebook']
-extras_require['testing'] += extras_require['notebook']
-
 # Option for user to install all runtime deps.
 extras_require['all'] = extras_require['proxy']
 

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,19 @@ extras_require = {
     ],
     'proxy': [
         'jupyter-server-proxy>=1.5.2'
+    ],
+    'notebook': [
+        # Needed only for notebook use:
+        'ipywidgets>=7.6.0',
+        'hypercorn>=0.11.0',
+        'ujson>=4.0.1',
+        'starlette==0.14.0',
+
+        # aiofiles is not explicitly referenced in our code,
+        # but it is an implicit dependency of starlette==0.14.0.
+        # https://github.com/encode/starlette/issues/49
+        # Upgrading starlette will remove this dependency.
+        'aiofiles>=0.6.0'
     ]
 }
 
@@ -94,10 +107,6 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     include_package_data=True,
     install_requires=[
-        'ipywidgets>=7.6.0',
-        'hypercorn>=0.11.0',
-        'ujson>=4.0.1',
-        'starlette==0.14.0',
         'zarr>=2.5.0',
         'numcodecs>=0.5.7',
         'scipy>=1.2.1',
@@ -106,12 +115,6 @@ setup_args = dict(
         'numpy>=1.21.2',
         'pandas>=1.1.2',
         'black>=21.11b1',
-
-        # aiofiles is not explicitly referenced in our code,
-        # but it is an implicit dependency of starlette==0.14.0.
-        # https://github.com/encode/starlette/issues/49
-        # Upgrading starlette will remove this dependency.
-        'aiofiles>=0.6.0'
     ],
     extras_require=extras_require,
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,11 @@ extras_require = {
         # but it is an implicit dependency of starlette==0.14.0.
         # https://github.com/encode/starlette/issues/49
         # Upgrading starlette will remove this dependency.
-        'aiofiles>=0.6.0'
+        'aiofiles>=0.6.0',
+
+        # These don't work in Python 3.6:
+        'numpy>=1.21.2',  # Last compatible version is 1.19.5
+        'generate-tiff-offsets>=0.1.7',  # Last compatible version is 2020.9.3
     ]
 }
 
@@ -111,8 +115,8 @@ setup_args = dict(
         'numcodecs>=0.5.7',
         'scipy>=1.2.1',
         'negspy>=0.2.24',
-        'generate-tiff-offsets>=0.1.7',
-        'numpy>=1.21.2',
+        # 'generate-tiff-offsets>=0.1.7',
+        # 'numpy>=1.21.2',
         'pandas>=1.1.2',
         'black>=21.11b1',
     ],

--- a/vitessce/__init__.py
+++ b/vitessce/__init__.py
@@ -41,7 +41,8 @@ except ModuleNotFoundError as e:
     from sys import version_info
     if version_info >= (3, 7):
         raise e
-    # If version < 3.7, these exports just aren't available
+    # If version < 3.7, these exports just aren't available.
+    # In the long term, probably best to drop partial support for 3.6, when it's no longer needed.
 
 try:
     if "google.colab" in sys.modules:

--- a/vitessce/__init__.py
+++ b/vitessce/__init__.py
@@ -41,7 +41,7 @@ except ModuleNotFoundError as e:
     from sys import version_info
     if version_info >= (3, 7):
         raise e
-    # If version < 3.7, these exports just aren't available.
+    # TODO: If version < 3.7, these exports just aren't available.
     # In the long term, probably best to drop partial support for 3.6, when it's no longer needed.
 
 try:

--- a/vitessce/__init__.py
+++ b/vitessce/__init__.py
@@ -35,7 +35,7 @@ try:
         export_to_s3,
         export_to_files,
     )
-except ImportError as e:
+except ModuleNotFoundError as e:
     from sys import version_info
     if version_info >= (3, 7):
         raise e

--- a/vitessce/__init__.py
+++ b/vitessce/__init__.py
@@ -12,15 +12,17 @@ from .config import (
 
 from .repr import make_repr
 
+from .constants import CoordinationType, Component, DataType, FileType
+
+from .wrappers import AbstractWrapper
+
 try:
     # We're trying to support config generation in Python 3.6 environments,
     # and so we allow installation without all of the dependencies that the widget requires.
     # The imports below will fail in that case, and corresponding globals will be undefined.
 
     from .widget import VitessceWidget
-    from .constants import CoordinationType, Component, DataType, FileType
     from .wrappers import (
-        AbstractWrapper,
         OmeTiffWrapper,
         MultiImageWrapper,
         AnnDataWrapper,

--- a/vitessce/__init__.py
+++ b/vitessce/__init__.py
@@ -2,7 +2,6 @@ import sys
 
 from ._version import __version__
 
-from .widget import VitessceWidget
 from .config import (
     VitessceConfig,
     VitessceChainableConfig,
@@ -10,24 +9,37 @@ from .config import (
     hconcat,
     vconcat,
 )
-from .constants import CoordinationType, Component, DataType, FileType
-from .wrappers import (
-    AbstractWrapper,
-    OmeTiffWrapper,
-    MultiImageWrapper,
-    AnnDataWrapper,
-    SnapWrapper,
-)
-from .entities import (
-    CellSets,
-    Cells,
-    Molecules,
-)
-from .export import (
-    export_to_s3,
-    export_to_files,
-)
+
 from .repr import make_repr
+
+try:
+    # We're trying to support config generation in Python 3.6 environments,
+    # and so we allow installation without all of the dependencies that the widget requires.
+    # The imports below will fail in that case, and corresponding globals will be undefined.
+
+    from .widget import VitessceWidget
+    from .constants import CoordinationType, Component, DataType, FileType
+    from .wrappers import (
+        AbstractWrapper,
+        OmeTiffWrapper,
+        MultiImageWrapper,
+        AnnDataWrapper,
+        SnapWrapper,
+    )
+    from .entities import (
+        CellSets,
+        Cells,
+        Molecules,
+    )
+    from .export import (
+        export_to_s3,
+        export_to_files,
+    )
+except ImportError as e:
+    from sys import version_info
+    if version_info >= (3, 7):
+        raise e
+    # If version < 3.7, these exports just aren't available
 
 try:
     if "google.colab" in sys.modules:

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -11,10 +11,6 @@ from .constants import (
     FileType as ft
 )
 
-from .export import (
-    export_to_s3,
-    export_to_files,
-)
 from .repr import make_repr, make_params_repr
 
 
@@ -1148,6 +1144,7 @@ class VitessceConfig:
 
             config_dict = vc.export(to="S3")
         """
+        from .export import (export_to_s3, export_to_files)
         if to == "S3":
             return export_to_s3(self, *args, **kwargs)
         elif to == "files":

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -1144,7 +1144,7 @@ class VitessceConfig:
 
             config_dict = vc.export(to="S3")
         """
-        from .export import (export_to_s3, export_to_files)
+        from .export import (export_to_s3, export_to_files)  # TODO: Move import back to top when this is factored out.
         if to == "S3":
             return export_to_s3(self, *args, **kwargs)
         elif to == "files":

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -11,10 +11,6 @@ from .constants import (
     FileType as ft
 )
 
-from .widget import (
-    VitessceWidget,
-    launch_vitessce_io,
-)
 from .export import (
     export_to_s3,
     export_to_files,
@@ -1101,6 +1097,7 @@ class VitessceConfig:
             vw = vc.widget()
             vw
         """
+        from .widget import VitessceWidget  # TODO: Move import back to top when this is factored out.
         return VitessceWidget(self, **kwargs)
 
     def web_app(self, **kwargs):
@@ -1127,6 +1124,7 @@ class VitessceConfig:
             vc.layout(v1)
             vc.web_app()
         """
+        from .widget import launch_vitessce_io  # TODO: Move import back to top when this is factored out.
         return launch_vitessce_io(self, **kwargs)
 
     def export(self, to, *args, **kwargs):

--- a/vitessce/export.py
+++ b/vitessce/export.py
@@ -6,7 +6,7 @@ from shutil import copyfile
 from starlette.routing import Mount
 from starlette.staticfiles import StaticFiles
 
-from .wrappers import JsonRoute
+from .routes import JsonRoute
 
 
 def export_to_s3(config, s3, bucket_name, prefix=''):

--- a/vitessce/routes.py
+++ b/vitessce/routes.py
@@ -1,4 +1,5 @@
 
+from starlette.routing import Route
 from starlette.responses import StreamingResponse
 from pathlib import Path
 
@@ -57,3 +58,9 @@ def range_repsonse(request, file_path):
         **headers,
     })
     return response
+
+
+class JsonRoute(Route):
+    def __init__(self, path, endpoint, data_json):
+        super().__init__(path, endpoint)
+        self.data_json = data_json

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -93,6 +93,7 @@ class AbstractWrapper:
             out_dir = self._get_out_dir(dataset_uid, obj_i)
             # TODO: Move imports back to top when this is factored out.
             from starlette.staticfiles import StaticFiles
+            from starlette.routing import Mount
             return [Mount(self._get_route_str(dataset_uid, obj_i),
                           app=StaticFiles(directory=out_dir, html=False))]
         return []
@@ -233,7 +234,7 @@ class OmeTiffWrapper(AbstractWrapper):
                 def __init__(self, path, endpoint, data_json):
                     super().__init__(path, endpoint)
                     self.data_json = data_json
-                    
+
             routes = [
                 Route(self._get_route_str(dataset_uid, obj_i, self._get_img_filename(
                 )), lambda req: range_repsonse(req, self._img_path)),

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -220,20 +220,15 @@ class OmeTiffWrapper(AbstractWrapper):
             return []
         else:
             # TODO: Move imports back to top when this is factored out.
-            from .routes import range_repsonse
+            from .routes import range_repsonse, JsonRoute
             from generate_tiff_offsets import get_offsets
-            from starlette.routing import Route
             from starlette.responses import UJSONResponse
+            from starlette.routing import Route
 
             offsets = get_offsets(self._img_path)
 
             async def response_func(req):
                 return UJSONResponse(offsets)
-
-            class JsonRoute(Route):
-                def __init__(self, path, endpoint, data_json):
-                    super().__init__(path, endpoint)
-                    self.data_json = data_json
 
             routes = [
                 Route(self._get_route_str(dataset_uid, obj_i, self._get_img_filename(

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -229,7 +229,6 @@ class OmeTiffWrapper(AbstractWrapper):
 
             async def response_func(req):
                 return UJSONResponse(offsets)
-
             routes = [
                 Route(self._get_route_str(dataset_uid, obj_i, self._get_img_filename(
                 )), lambda req: range_repsonse(req, self._img_path)),


### PR DESCRIPTION
- Fix #127 
- Replace #147

Reached out to Mark for guidance on the best way forward:

> Thanks for the feedback, and sorry this has been drawn out: I finally got it to install under Python 3.6 😄  … but I needed to take out numpy and generate-tiff-offsets ☹️  . Do you have a sense of the best way forward from here?
> - Try to downgrade these dependencies to a version that is supported under Python 3.6?
> - Or move the imports down inside GenomicProfiles and SnapWrapper and OmeTiffWrapper ?
> - Or a combination?
> - Or give up — Trying to support compatibility with 3.6 might just not be worth it?

Went with moving the imports down... this gets pretty kludgy -- Unless identifying the dependencies will make a future clean up easier, I have misgivings about pushing this in.