### PR TITLE
install flake8 from extras

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,5 +11,5 @@ jobs:
         with:
           python-version: '3.8'
           architecture: 'x64'
-      - run: pip install flake8
+      - run: pip install .[linting]
       - run: flake8

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,9 @@ extras_require = {
         'anndata==0.7.8',
         'loompy>=3.0.6',
     ],
+    'linting': [
+        'flake8==3.8.4',
+    ],
     'docs': [
         'sphinx==4.2.0',
         'sphinx-rtd-theme==1.0.0',

--- a/setup.py
+++ b/setup.py
@@ -66,9 +66,6 @@ extras_require = {
         'anndata==0.7.8',
         'loompy>=3.0.6',
     ],
-    'linting': [
-        'flake8==3.8.4',
-    ],
     'docs': [
         'sphinx==4.2.0',
         'sphinx-rtd-theme==1.0.0',


### PR DESCRIPTION
This ensures that CI is installing the same version a developer will install. (Initially, I thought about simplifying by getting rid of the extra, but then thought better of it.)