### PR TITLE
Mccalluc/just warn if imports fail

### DIFF
--- a/vitessce/__init__.py
+++ b/vitessce/__init__.py
@@ -1,4 +1,5 @@
 import sys
+from warnings import warn
 
 from ._version import __version__
 
@@ -16,31 +17,41 @@ from .constants import CoordinationType, Component, DataType, FileType
 
 from .wrappers import AbstractWrapper
 
-try:
-    # We're trying to support config generation in Python 3.6 environments,
-    # and so we allow installation without all of the dependencies that the widget requires.
-    # The imports below will fail in that case, and corresponding globals will be undefined.
 
+# We're trying to support config generation in Python 3.6 environments,
+# and so we allow installation without all of the dependencies that the widget requires.
+# The imports below will fail in that case, and corresponding globals will be undefined.
+try:
     from .widget import VitessceWidget
+except ModuleNotFoundError as e:
+    warn(f'Extra installs are necessary to use widgets: {e}')
+
+try:
     from .wrappers import (
         OmeTiffWrapper,
         MultiImageWrapper,
         AnnDataWrapper,
         SnapWrapper,
     )
+except ModuleNotFoundError as e:
+    warn(f'Extra installs are necessary to use wrappers: {e}')
+
+try:
     from .entities import (
         CellSets,
         Cells,
         Molecules,
     )
+except ModuleNotFoundError as e:
+    warn(f'Extra installs are necessary to use entities: {e}')
+
+try:
     from .export import (
         export_to_s3,
         export_to_files,
     )
 except ModuleNotFoundError as e:
-    from warnings import warn
-    warn('Some functionality not available because notebook dependencies are missing')
-
+    warn(f'Extra installs are necessary to use exports: {e}')
 
 try:
     if "google.colab" in sys.modules:

--- a/vitessce/__init__.py
+++ b/vitessce/__init__.py
@@ -38,11 +38,9 @@ try:
         export_to_files,
     )
 except ModuleNotFoundError as e:
-    from sys import version_info
-    if version_info >= (3, 7):
-        raise e
-    # TODO: If version < 3.7, these exports just aren't available.
-    # In the long term, probably best to drop partial support for 3.6, when it's no longer needed.
+    from warnings import warn
+    warn('Some functionality not available because notebook dependencies are missing')
+
 
 try:
     if "google.colab" in sys.modules:


### PR DESCRIPTION
We want the failover logic to be the same regardless of python version. I'm also splitting it into separate chunks, so one failing import won't block all the rest.

<hr />

Just a footnote: I'm sorry that this process has been drawn out. I've wondered if an end-to-end integration test with portal-visualization would make sense, but I'm not sure how to make that work without it being really kludgy. It would be something like:
```
cd /tmp
git clone .../portal-visualization
cd portal-visualization
pip install ... # list dependencies individually, because if we install everything, it gets a pinned version of vitessce-python
test.sh # Run portal-visualizations test suite, but using the version of vitessce-python here.
```
Besides being kludgy, it's just not working when I try it locally:
```
...
ERROR src/vis-preview.py - ModuleNotFoundError: No module named 'hubmap_commons'
ERROR test/test_builders.py - ModuleNotFoundError: No module named 'yaml'
ERROR test/test_builders.py
...
3 errors in 1.49s

$ pip freeze | grep commons
hubmap-commons==2.0.14
```
I don't get why python isn't seeing commons in this environment.

Anyway... I guess if you would be excited about having more of an integration test test here, I'll work on that, but that's not the direction I'm going right now... which might mean there is more back and forth until this works.