### PR TITLE
Fix npm ci step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,11 +24,13 @@ jobs:
         run: pip install -e .[dev]
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - name: NPM CI
         working-directory: ./js
-        run: npm ci && npm run clean
+        run: |
+          npm install -g npm@6.14.16
+          npm ci && npm run clean
         shell: /bin/bash -e {0}
       - name: Build nbextension
         working-directory: ./js

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - uses: actions/setup-python@v2
         with:
@@ -21,7 +21,9 @@ jobs:
         run: pip install -e .[dev]
       - name: NPM CI
         working-directory: ./js
-        run: npm ci && npm run clean
+        run: |
+          npm install -g npm@6.14.16
+          npm ci && npm run clean
         shell: /bin/bash -e {0}
       - name: Build nbextension
         working-directory: ./js


### PR DESCRIPTION
Downgrade Node and NPM to reflect versions in https://github.com/vitessce/vitessce/blob/main/.github/workflows/deploy.yml#L23

I have experienced similar issues with Node/NPM versions, I am not sure the root issue but I think it may have to do with not pinning the `npm` version (and differences in the more recent `npm` versions)

Fixes #186 