### PR TITLE
Pin ipywidgets dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.10
+
+### Changed
+- Pin `ipywidgets` and `jupyterlab-widgets` dependency versions as a short-term fix. In the longer term, we will need to follow the [migration guide](https://ipywidgets.readthedocs.io/en/stable/migration_guides.html#migrating-from-7-x-to-8-0).
 
 ## 1.0.5 - in progress
 

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,8 @@ extras_require = {
     ],
     'notebook': [
         # Needed only for notebook use:
-        'ipywidgets>=7.6.0',
+        'ipywidgets<=7.7.2',
+        'jupyterlab-widgets<=1.1.1',
         'hypercorn>=0.11.0',
         'ujson>=4.0.1',
         'starlette==0.14.0',

--- a/vitessce/_version.py
+++ b/vitessce/_version.py
@@ -1,5 +1,5 @@
 # Module version
-py_version_info = (1, 0, 9)
+py_version_info = (1, 0, 10)
 js_version_info = (0, 1, 14)
 
 # Module version accessible using vitessce.__version__


### PR DESCRIPTION
The release of ipywidgets 8.0.0 caused the change in behavior upon installing the vitessce package.