### PR TITLE
Create smaller easier-to-solve CI env

### DIFF
--- a/.github/workflows/test_demos.yml
+++ b/.github/workflows/test_demos.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: vitessce-python-demos
-          environment-file: demos/environment.yml
+          activate-environment: vitessce-python-demos-dryrun
+          environment-file: demos/dryrun_environment.yml
           python-version: 3.8
           use-mamba: true
           mamba-version: "*"

--- a/demos/dryrun_environment.yml
+++ b/demos/dryrun_environment.yml
@@ -1,0 +1,8 @@
+name: vitessce-python-demos-dryrun
+channels:
+ - bioconda
+ - conda-forge
+dependencies:
+ - python==3.8
+ - snakemake>=6.0
+ - pyyaml


### PR DESCRIPTION
The demos environment takes hours to solve via conda/mamba https://github.com/conda-incubator/setup-miniconda/issues/196#issuecomment-1376320682

This PR sets up a minimal environment with only the dependencies needed to run the snakemake dryrun in the GitHub action. Not an ideal solution but seems to work.