### PR TITLE
Add VitessceConfig.display

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ vw
 vw.config
 ```
 
-## Usage when Jupyter is running on a remote machine
+### Usage when Jupyter is running on a remote machine
 
 If Jupyter is running on a remote machine, then use `proxy=True`. You may need to specify `host_name` as well (`widget` should be able to detect this but the plain `display` cannot).
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,33 @@ To deploy a new version, increment the version of the Python package in [`setup.
 
 Then, when you push or merge the code with the incremented versions to `main`, the GitHub Action `deploy.yml` workflow will build and push the package to PyPI.
 
+## Troubleshooting
+
+### Check JavaScript console
+
+Check the JavaScript console in the web browser for error messages. To do so, shift+right click in Jupyter, then click Inspect element. You may need to enable your browser's develop mode in its preferences for this option to appear when you right-click.
+
+### Check your Python environment
+
+Check that you have activated the correct conda or other virtual environment as you expect.
+When sharing errors, it can be helpful to share the current versions of packages in the environment, e.g., by `conda list` or `pip list`.
+
+### Restart Kernel and Clear All Outputs, then refresh the browser tab
+
+To ensure that older widget JavaScript output is not causing conflicts with newer JavaScript output (which may persist via notebook outputs even without running notebook cells), clear old outputs by Kernel -> Restart Kernel and Clear All Outputs. Then refresh the browser tab (containing Jupyter) to ensure all JavaScript outputs are fresh.
+
+### Check the widget configuration
+
+If the widget renders successfully, you can get its current configuration by
+
+```py
+vw = vc.widget()
+vw
+```
+
+```py
+vw.config
+```
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ vw
 vw.config
 ```
 
+## Usage when Jupyter is running on a remote machine
+
+If Jupyter is running on a remote machine, then use `proxy=True`. You may need to specify `host_name` as well (`widget` should be able to detect this but the plain `display` cannot).
+
+```py
+vw = vc.widget(proxy=True)
+vw
+```
+
+or 
+
+```py
+vc.display(proxy=True, host_name="http://localhost:8888")
+```
+
+
 ## Resources
 
 - [ipywidget docs: Building a Custom Widget](https://ipywidgets.readthedocs.io/en/stable/examples/Widget%20Custom.html)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 from distutils import log
 
 # Module version
-py_version_info = (3, 0, 1)
+py_version_info = (3, 0, 2)
 __version__ = '%s.%s.%s' % (py_version_info[0], py_version_info[1], py_version_info[2])
 
 # Setup

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -1117,6 +1117,10 @@ class VitessceConfig:
         :param int port: The port to use when serving data objects on localhost. By default, 8000.
         :param base_url: If the web app is being accessed remotely (i.e. the data is being served from a remote machine), specify the base URL here. If serving and accessing the data on the same machine, keep as None to use a localhost URL.
         :type base_url: str or None
+        :param host_name: The host name where the Jupyter server is running, e.g. "http://localhost:8888". By default, None.
+        :type host_name: str or None
+        :param bool proxy: Is this widget being served through a proxy, for example with a cloud notebook? If True, host_name should be provided.
+        
         :param bool open: Should the browser be opened to the web app URL? By default, True.
 
         :returns: The URL of the web app (containing the Vitessce configuration as URL-encoded JSON).
@@ -1135,6 +1139,37 @@ class VitessceConfig:
         """
         from .widget import launch_vitessce_io  # TODO: Move import back to top when this is factored out.
         return launch_vitessce_io(self, **kwargs)
+    
+    def display(self, **kwargs):
+        """
+        Launch the http://vitessce.io web app using this config.
+
+        :param str theme: The theme name, either "light" or "dark". By default, "auto", which selects light or dark based on operating system preferences.
+        :param int port: The port to use when serving data objects on localhost. By default, 8000.
+        :param base_url: If the web app is being accessed remotely (i.e. the data is being served from a remote machine), specify the base URL here. If serving and accessing the data on the same machine, keep as None to use a localhost URL.
+        :type base_url: str or None
+        :param host_name: The host name where the Jupyter server is running, e.g. "http://localhost:8888". By default, None.
+        :type host_name: str or None
+        :param bool proxy: Is this widget being served through a proxy, for example with a cloud notebook? If True, host_name should be provided.
+        
+        :param bool open: Should the browser be opened to the web app URL? By default, True.
+
+        :returns: The URL of the web app (containing the Vitessce configuration as URL-encoded JSON).
+        :rtype: str
+
+        .. code-block:: python
+            :emphasize-lines: 6
+
+            from vitessce import VitessceConfig, ViewType as vt, CoordinationType as ct
+
+            vc = VitessceConfig(schema_version="1.0.15")
+            my_dataset = vc.add_dataset(name='My Dataset')
+            v1 = vc.add_view(vt.SPATIAL, dataset=my_dataset)
+            vc.layout(v1)
+            vc.display()
+        """
+        from .widget import ipython_display
+        return ipython_display(self, **kwargs)
 
     def export(self, to, *args, **kwargs):
         """

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -1120,7 +1120,7 @@ class VitessceConfig:
         :param host_name: The host name where the Jupyter server is running, e.g. "http://localhost:8888". By default, None.
         :type host_name: str or None
         :param bool proxy: Is this widget being served through a proxy, for example with a cloud notebook? If True, host_name should be provided.
-        
+
         :param bool open: Should the browser be opened to the web app URL? By default, True.
 
         :returns: The URL of the web app (containing the Vitessce configuration as URL-encoded JSON).
@@ -1139,7 +1139,7 @@ class VitessceConfig:
         """
         from .widget import launch_vitessce_io  # TODO: Move import back to top when this is factored out.
         return launch_vitessce_io(self, **kwargs)
-    
+
     def display(self, **kwargs):
         """
         Launch the http://vitessce.io web app using this config.
@@ -1151,7 +1151,7 @@ class VitessceConfig:
         :param host_name: The host name where the Jupyter server is running, e.g. "http://localhost:8888". By default, None.
         :type host_name: str or None
         :param bool proxy: Is this widget being served through a proxy, for example with a cloud notebook? If True, host_name should be provided.
-        
+
         :param bool open: Should the browser be opened to the web app URL? By default, True.
 
         :returns: The URL of the web app (containing the Vitessce configuration as URL-encoded JSON).

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -1142,7 +1142,7 @@ class VitessceConfig:
 
     def display(self, **kwargs):
         """
-        Launch the http://vitessce.io web app using this config.
+        As a fallback to widget, render Vitessce using functions from IPython.display. This method does not support bi-directional communication (i.e., user interactions in Vitessce cannot be sent back to Python).
 
         :param str theme: The theme name, either "light" or "dark". By default, "auto", which selects light or dark based on operating system preferences.
         :param int port: The port to use when serving data objects on localhost. By default, 8000.
@@ -1151,11 +1151,6 @@ class VitessceConfig:
         :param host_name: The host name where the Jupyter server is running, e.g. "http://localhost:8888". By default, None.
         :type host_name: str or None
         :param bool proxy: Is this widget being served through a proxy, for example with a cloud notebook? If True, host_name should be provided.
-
-        :param bool open: Should the browser be opened to the web app URL? By default, True.
-
-        :returns: The URL of the web app (containing the Vitessce configuration as URL-encoded JSON).
-        :rtype: str
 
         .. code-block:: python
             :emphasize-lines: 6

--- a/vitessce/widget.py
+++ b/vitessce/widget.py
@@ -138,6 +138,7 @@ def launch_vitessce_io(config, theme='light', port=None, base_url=None, host_nam
         webbrowser.open(vitessce_url)
     return vitessce_url
 
+
 def get_uid_str(uid):
     if uid is None or not str(uid).isalnum():
         uid_str = str(uuid.uuid4())[:4]
@@ -362,6 +363,8 @@ class VitessceWidget(anywidget.AnyWidget):
         super().close()
 
 # Launch Vitessce using plain HTML representation (no ipywidgets)
+
+
 def ipython_display(config, height=600, theme='auto', base_url=None, host_name=None, uid=None, port=None, proxy=False, js_package_version='2.0.3', custom_js_url=''):
     from IPython.display import display, HTML
     uid_str = "vitessce" + get_uid_str(uid)

--- a/vitessce/widget.py
+++ b/vitessce/widget.py
@@ -90,7 +90,7 @@ def is_port_in_use(port):
         return s.connect_ex(('localhost', port)) == 0
 
 
-def get_base_url_and_port(port, next_port, proxy=False, base_url=None):
+def get_base_url_and_port(port, next_port, proxy=False, base_url=None, host_name=None):
     if port is None:
         use_port = next_port
         next_port += 1
@@ -107,7 +107,10 @@ def get_base_url_and_port(port, next_port, proxy=False, base_url=None):
             if importlib.util.find_spec('jupyter_server_proxy') is None:
                 raise ValueError(
                     "To use the widget through a proxy, jupyter-server-proxy must be installed.")
-            base_url = f"proxy/{use_port}"
+            if host_name is None:
+                base_url = f"proxy/{use_port}"
+            else:
+                base_url = f"{host_name}/proxy/{use_port}"
         else:
             base_url = f"http://localhost:{use_port}"
 
@@ -122,10 +125,10 @@ def serve_routes(config, routes, use_port):
         server.start(port=use_port)
 
 
-def launch_vitessce_io(config, theme='light', port=None, base_url=None, open=True):
+def launch_vitessce_io(config, theme='light', port=None, base_url=None, host_name=None, proxy=False, open=True):
     import webbrowser
     base_url, use_port, _ = get_base_url_and_port(
-        port, DEFAULT_PORT, base_url=base_url)
+        port, DEFAULT_PORT, proxy=proxy, base_url=base_url, host_name=host_name)
     config_dict = config.to_dict(base_url=base_url)
     routes = config.get_routes()
     serve_routes(config, routes, use_port)
@@ -134,6 +137,13 @@ def launch_vitessce_io(config, theme='light', port=None, base_url=None, open=Tru
     if open:
         webbrowser.open(vitessce_url)
     return vitessce_url
+
+def get_uid_str(uid):
+    if uid is None or not str(uid).isalnum():
+        uid_str = str(uuid.uuid4())[:4]
+    else:
+        uid_str = uid
+    return uid_str
 
 
 ESM = """
@@ -155,8 +165,8 @@ const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-schem
 // The jupyter server may be running through a proxy,
 // which means that the client needs to prepend the part of the URL before /proxy/8000 such as
 // https://hub.gke2.mybinder.org/user/vitessce-vitessce-python-swi31vcv/proxy/8000/A/0/cells
-function prependBaseUrl(config, proxy) {
-  if(!proxy) {
+function prependBaseUrl(config, proxy, hasHostName) {
+  if(!proxy || hasHostName) {
     return config;
   }
   const { origin } = new URL(window.location.href);
@@ -210,7 +220,7 @@ export function render(view) {
     function VitessceWidget(props) {
         const { model } = props;
 
-        const config = prependBaseUrl(model.get('config'), model.get('proxy'));
+        const config = prependBaseUrl(model.get('config'), model.get('proxy'), model.get('has_host_name'));
         const height = model.get('height');
         const theme = model.get('theme') === 'auto' ? (prefersDark ? 'dark' : 'light') : model.get('theme');
 
@@ -279,13 +289,14 @@ class VitessceWidget(anywidget.AnyWidget):
     theme = Unicode('auto').tag(sync=True)
     proxy = Bool(False).tag(sync=True)
     uid = Unicode('').tag(sync=True)
+    has_host_name = Bool(False).tag(sync=True)
 
     next_port = DEFAULT_PORT
 
-    js_package_version = Unicode('2.0.3-beta.0').tag(sync=True)
+    js_package_version = Unicode('2.0.3').tag(sync=True)
     custom_js_url = Unicode('').tag(sync=True)
 
-    def __init__(self, config, height=600, theme='auto', uid=None, port=None, proxy=False, js_package_version='2.0.3-beta.0', custom_js_url=''):
+    def __init__(self, config, height=600, theme='auto', uid=None, port=None, proxy=False, js_package_version='2.0.3', custom_js_url=''):
         """
         Construct a new Vitessce widget.
 
@@ -313,10 +324,7 @@ class VitessceWidget(anywidget.AnyWidget):
         config_dict = config.to_dict(base_url=base_url)
         routes = config.get_routes()
 
-        if uid is None:
-            uid_str = str(uuid.uuid4())[:4]
-        else:
-            uid_str = uid
+        uid_str = get_uid_str(uid)
 
         super(VitessceWidget, self).__init__(
             config=config_dict, height=height, theme=theme, proxy=proxy,
@@ -352,3 +360,47 @@ class VitessceWidget(anywidget.AnyWidget):
     def close(self):
         self.config_obj.stop_server(self.port)
         super().close()
+
+# Launch Vitessce using plain HTML representation (no ipywidgets)
+def ipython_display(config, height=600, theme='auto', base_url=None, host_name=None, uid=None, port=None, proxy=False, js_package_version='2.0.3', custom_js_url=''):
+    from IPython.display import display, HTML
+    uid_str = "vitessce" + get_uid_str(uid)
+
+    base_url, use_port, _ = get_base_url_and_port(
+        port, DEFAULT_PORT, proxy=proxy, base_url=base_url, host_name=host_name)
+    config_dict = config.to_dict(base_url=base_url)
+    routes = config.get_routes()
+    serve_routes(config, routes, use_port)
+
+    model_vals = {
+        "uid": uid_str,
+        "js_package_version": js_package_version,
+        "custom_js_url": custom_js_url,
+        "proxy": proxy,
+        "has_host_name": host_name is not None,
+        "height": height,
+        "theme": theme,
+        "config": config_dict,
+    }
+
+    HTML_STR = f"""
+        <div id="{uid_str}"></div>
+
+        <script type="module">
+
+            """ + ESM + """
+
+            render({
+                model: {
+                    get: (key) => {
+                        const vals = """ + json.dumps(model_vals) + """;
+                        return vals[key];
+                    },
+                    set: () => {},
+                    save_changes: () => {}
+                },
+                el: """ + f"""document.getElementById("{uid_str}")""" + """,
+            });
+        </script>
+    """
+    display(HTML(HTML_STR))


### PR DESCRIPTION
As another fallback after `.widget` and `.web_app`, this adds `.display` to render Vitessce with only unidirectional communication in the notebook using the ipython display HTML function.