### PR TITLE
Upgrade dynamic-import package version to fix bug

### DIFF
--- a/vitessce/widget.py
+++ b/vitessce/widget.py
@@ -148,7 +148,7 @@ def get_uid_str(uid):
 
 
 ESM = """
-import { importWithMap } from 'https://unpkg.com/dynamic-importmap@0.0.1';
+import { importWithMap } from 'https://unpkg.com/dynamic-importmap@0.1.0';
 const importMap = {
   imports: {
     "react": "https://esm.sh/react@18.2.0?dev",


### PR DESCRIPTION
Fixes issue with dynamic JS `await import()` which is used by Viv internals/dependencies for loading OME-TIFF