### PR TITLE
NickAkhmetov/Add support for `obs_labels_names` and `obs_labels_paths` arrays

### DIFF
--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -139,7 +139,7 @@ def create_test_anndata_file(h5ad_path):
         'exPFC2',
         'GABA2'
     ]
-    obs_cell_label_arr = [f'{l}-label' for l in obs_celltype_arr]
+    obs_cell_label_arr = [f'{obs_label}-label' for obs_label in obs_celltype_arr]
     obs_df = pd.DataFrame(
         data=[
             {'index': i, 'CellType': ct, 'CellLabel': cl}

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -139,10 +139,11 @@ def create_test_anndata_file(h5ad_path):
         'exPFC2',
         'GABA2'
     ]
+    obs_cell_label_arr = [f'{l}-label' for l in obs_celltype_arr]
     obs_df = pd.DataFrame(
         data=[
-            {'index': i, 'CellType': ct}
-            for i, ct in zip(obs_index_arr, obs_celltype_arr)
+            {'index': i, 'CellType': ct, 'CellLabel': cl}
+            for i, ct, cl in zip(obs_index_arr, obs_celltype_arr, obs_cell_label_arr)
         ]
     )
     obsm = {"X_umap": np.array([[0, 1] for c in obs_index_arr])}

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -141,8 +141,10 @@ class TestWrappers(unittest.TestCase):
 
     def test_anndata(self):
         adata_path = data_path / 'test.h5ad.zarr'
-        w = AnnDataWrapper(adata_path, obs_set_paths=['obs/CellType'], obs_set_names=['Cell Type'], obs_embedding_paths=[
-                           'obsm/X_umap'], obs_embedding_names=['UMAP'])
+        w = AnnDataWrapper(adata_path,
+                           obs_set_paths=['obs/CellType'], obs_set_names=['Cell Type'],
+                           obs_labels_names=['Cell Label'], obs_labels_paths=['obs/CellLabel'],
+                           obs_embedding_paths=['obsm/X_umap'], obs_embedding_names=['UMAP'])
         w.local_dir_uid = 'anndata.zarr'
 
         file_def_creator = w.make_file_def_creator('A', 0)
@@ -150,7 +152,8 @@ class TestWrappers(unittest.TestCase):
         self.assertEqual(file_def, {'fileType': 'anndata.zarr', 'url': 'http://localhost:8000/A/0/anndata.zarr',
                                     'options': {
                                         'obsEmbedding': [{'path': 'obsm/X_umap', 'embeddingType': 'UMAP', 'dims': [0, 1]}],
-                                        'obsSets': [{'path': 'obs/CellType', 'name': 'Cell Type'}]
+                                        'obsSets': [{'path': 'obs/CellType', 'name': 'Cell Type'}],
+                                        'obsLabels': [{'path': 'obs/CellLabel', 'obsLabelsType': 'Cell Label'}]
                                     }})
 
     def test_anndata_with_base_dir(self):

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -516,15 +516,15 @@ class AnnDataWrapper(AbstractWrapper):
         :param str feature_filter_path: A string like `var/highly_variable` used in conjunction with `obs_feature_matrix_path` if obs_feature_matrix_path points to a subset of `X` of the full `var` list.
         :param str initial_feature_filter_path: A string like `var/highly_variable` used in conjunction with `obs_feature_matrix_path` if obs_feature_matrix_path points to a subset of `X` of the full `var` list.
         :param list[str] obs_set_paths: Column names like `['obs/louvain', 'obs/cellType']` for showing cell sets
-        :param list[str] obs_set_names: Names to display in place of those in `obs_set_paths`, like `['Louvain', 'Cell Type']
+        :param list[str] obs_set_names: Names to display in place of those in `obs_set_paths`, like `['Louvain', 'Cell Type']`
         :param str obs_locations_path: Column name in `obsm` that contains centroid coordinates for displaying centroids in the spatial viewer
         :param str obs_segmentations_path: Column name in `obsm` that contains polygonal coordinates for displaying outlines in the spatial viewer
         :param list[str] obs_embedding_paths: Column names like `['obsm/X_umap', 'obsm/X_pca']` for showing scatterplots
-        :param list[str] obs_embedding_names: Overriding names like `['UMAP', 'PCA'] for displaying above scatterplots
-        :param list[str] obs_embedding_dims: Dimensions along which to get data for the scatterplot, like [[0, 1], [4, 5]] where [0, 1] is just the normal x and y but [4, 5] could be comparing the third and fourth principal components, for example.
-        :param dict request_init: options to be passed along with every fetch request from the browser, like { "header": { "Authorization": "Bearer dsfjalsdfa1431" } }
+        :param list[str] obs_embedding_names: Overriding names like `['UMAP', 'PCA']` for displaying above scatterplots
+        :param list[str] obs_embedding_dims: Dimensions along which to get data for the scatterplot, like `[[0, 1], [4, 5]]` where `[0, 1]` is just the normal x and y but `[4, 5]` could be comparing the third and fourth principal components, for example.
+        :param dict request_init: options to be passed along with every fetch request from the browser, like `{ "header": { "Authorization": "Bearer dsfjalsdfa1431" } }`
         :param str feature_labels_path: The name of a column containing feature labels (e.g., alternate gene symbols), instead of the default index in `var` of the AnnData store.
-        :param str obs_labels_path: The name of a column containing observation labels (e.g., alternate cell IDs), instead of the default index in `obs` of the AnnData store.
+        :param str obs_labels_path: (DEPRECATED) The name of a column containing observation labels (e.g., alternate cell IDs), instead of the default index in `obs` of the AnnData store. Use `obs_labels_paths` and `obs_labels_names` instead. This arg will be removed in a future release.
         :param list[str] obs_labels_paths: The names of columns containing observation labels (e.g., alternate cell IDs), instead of the default index in `obs` of the AnnData store.
         :param list[str] obs_labels_names: The optional display names of columns containing observation labels (e.g., alternate cell IDs), instead of the default index in `obs` of the AnnData store.
         :param bool convert_to_dense: Whether or not to convert `X` to dense the zarr store (dense is faster but takes more disk space).

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -564,7 +564,7 @@ class AnnDataWrapper(AbstractWrapper):
         # Support legacy provision of single obs labels path
         if (obs_labels_path is not None):
             self._obs_labels_paths = [obs_labels_path]
-            self._obs_labels_names = [obs_labels_path]
+            self._obs_labels_names = [obs_labels_path.split('/')[-1]]
         else:
             self._obs_labels_paths = obs_labels_paths
             self._obs_labels_names = obs_labels_names
@@ -650,10 +650,17 @@ class AnnDataWrapper(AbstractWrapper):
                 options["featureLabels"] = {
                     "path": self._gene_alias
                 }
-            if self._obs_labels_paths is not None and self._obs_labels_names is not None and len(self._obs_labels_paths) == len(self._obs_labels_names):
+            if self._obs_labels_paths is not None:
+                if self._obs_labels_names is not None and len(self._obs_labels_paths) == len(self._obs_labels_names):
+                    # A name was provided for each path element, so use those values.
+                    names = self._obs_labels_names
+                else:
+                    # Names were not provided for each path element,
+                    # so fall back to using the final part of each path for the names.
+                    names = [labels_path.split('/')[-1] for labels_path in self._obs_labels_paths]
                 obs_labels = []
-                for path, obs_type in zip(self._obs_labels_paths, self._obs_labels_names):
-                    obs_labels.append({"path": path, "obsLabelsType": obs_type})
+                for path, name in zip(self._obs_labels_paths, names):
+                    obs_labels.append({"path": path, "obsLabelsType": name})
                 options["obsLabels"] = obs_labels
             if len(options.keys()) > 0:
                 obj_file_def = {

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -506,7 +506,7 @@ class OmeZarrWrapper(AbstractWrapper):
 
 
 class AnnDataWrapper(AbstractWrapper):
-    def __init__(self, adata_path=None, adata_url=None, obs_feature_matrix_path=None, feature_filter_path=None, initial_feature_filter_path=None, obs_set_paths=None, obs_set_names=None, obs_locations_path=None, obs_segmentations_path=None, obs_embedding_paths=None, obs_embedding_names=None, obs_embedding_dims=None, request_init=None, feature_labels_path=None, obs_labels_path=None, convert_to_dense=True, coordination_values=None, **kwargs):
+    def __init__(self, adata_path=None, adata_url=None, obs_feature_matrix_path=None, feature_filter_path=None, initial_feature_filter_path=None, obs_set_paths=None, obs_set_names=None, obs_locations_path=None, obs_segmentations_path=None, obs_embedding_paths=None, obs_embedding_names=None, obs_embedding_dims=None, request_init=None, feature_labels_path=None, obs_labels_path=None, convert_to_dense=True, coordination_values=None, obs_labels_paths=None, obs_labels_names=None, **kwargs):
         """
         Wrap an AnnData object by creating an instance of the ``AnnDataWrapper`` class.
 
@@ -525,6 +525,8 @@ class AnnDataWrapper(AbstractWrapper):
         :param dict request_init: options to be passed along with every fetch request from the browser, like { "header": { "Authorization": "Bearer dsfjalsdfa1431" } }
         :param str feature_labels_path: The name of a column containing feature labels (e.g., alternate gene symbols), instead of the default index in `var` of the AnnData store.
         :param str obs_labels_path: The name of a column containing observation labels (e.g., alternate cell IDs), instead of the default index in `obs` of the AnnData store.
+        :param list[str] obs_labels_paths: The names of columns containing observation labels (e.g., alternate cell IDs), instead of the default index in `obs` of the AnnData store.
+        :param list[str] obs_labels_names: The optional display names of columns containing observation labels (e.g., alternate cell IDs), instead of the default index in `obs` of the AnnData store.
         :param bool convert_to_dense: Whether or not to convert `X` to dense the zarr store (dense is faster but takes more disk space).
         :param coordination_values: Coordination values for the file definition.
         :type coordination_values: dict or None
@@ -559,7 +561,13 @@ class AnnDataWrapper(AbstractWrapper):
         self._mappings_obsm_dims = obs_embedding_dims
         self._request_init = request_init
         self._gene_alias = feature_labels_path
-        self._obs_labels_path = obs_labels_path
+        # Support legacy provision of single obs labels path
+        if (obs_labels_path is not None):
+            self._obs_labels_paths = [obs_labels_path]
+            self._obs_labels_names = [obs_labels_path]
+        else:
+            self._obs_labels_paths = obs_labels_paths
+            self._obs_labels_names = obs_labels_names
         self._convert_to_dense = convert_to_dense
         self._coordination_values = coordination_values
 
@@ -642,10 +650,11 @@ class AnnDataWrapper(AbstractWrapper):
                 options["featureLabels"] = {
                     "path": self._gene_alias
                 }
-            if self._obs_labels_path is not None:
-                options["obsLabels"] = {
-                    "path": self._obs_labels_path
-                }
+            if self._obs_labels_paths is not None and self._obs_labels_names is not None and len(self._obs_labels_paths) == len(self._obs_labels_names):
+                obs_labels = []
+                for path, obs_type in zip(self._obs_labels_paths, self._obs_labels_names):
+                    obs_labels.append({"path": path, "obsLabelsType": obs_type})
+                options["obsLabels"] = obs_labels
             if len(options.keys()) > 0:
                 obj_file_def = {
                     "fileType": ft.ANNDATA_ZARR.value,


### PR DESCRIPTION
This PR adds support and tests for the `obs_labels_names` and `obs_labels_paths` props for the AnndataWrapper to allow passing more than one set of obs labels and corresponding display names. I kept the legacy `obs_labels_path` prop in place but indicated it is deprecated.