### PR TITLE
NickAkhmetov/Add `allow_multiple_scopes_per_type` boolean arg to `use_coordination` and `link_views`

### DIFF
--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -832,7 +832,7 @@ class VitessceConfig:
         :type c_types: list of str or list of vitessce.constants.CoordinationType
         :param list c_values: Initial values corresponding to each coordination type. Should have the same length as the c_types array. Optional.
         :param bool allow_multiple_scopes_per_type: Whether to allow multiple coordination scopes per coordination type. If true, multiple values for the same coordination type are treated as a list. If false, latest value for same coordination type is used. Defaults to False.
-        
+
         :returns: Self, to allow chaining.
         :rtype: VitessceConfig
         """

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -403,7 +403,7 @@ class VitessceConfigView:
         """
         for c_scope in c_scopes:
             assert isinstance(c_scope, VitessceConfigCoordinationScope)
-            existing_value = self.view["coordinationScopes"][c_scope.c_type]
+            existing_value = self.view["coordinationScopes"].get(c_scope.c_type)
             new_value = c_scope.c_scope
             if (existing_value is not None and allow_multiple_scopes_per_type):
                 if (isinstance(existing_value, list)):

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -407,7 +407,7 @@ class VitessceConfigView:
             new_value = c_scope.c_scope
             if (existing_value is not None and allow_multiple_scopes_per_type):
                 if (isinstance(existing_value, list)):
-                    self.view["coordinationScopes"][c_scope.c_type] = existing_value.append(new_value)
+                    self.view["coordinationScopes"][c_scope.c_type] = existing_value + [new_value]
                 else:
                     self.view["coordinationScopes"][c_scope.c_type] = [existing_value, new_value]
             else:


### PR DESCRIPTION
Fixes #271 

This PR allows for multiple coordination scopes of a single type to be used by a single view. This allows e.g. the use of multiple `obsLabelsType` coordinations at once.