### PR TITLE
Release 3.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.7 - 2023-08-11
+### Changed
+- Added support for multiple coordination scopes of the same type using the `allow_multiple_scopes_per_type` named arg
+- Added new `CoordinationType`s and `FileType`s
+- Added support for `obs_labels_names` and `obs_labels_paths` in AnndataWrapper
+
 ## 1.0.10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ make html
 
 ## Deployment
 
-To deploy a new version, increment the version of the Python package in [`setup.py`](./setup.py).
+To deploy a new version, increment the version of the Python package in [`pyproject.toml`](./pyproject.toml).
 
 Then, when you push or merge the code with the incremented versions to `main`, the GitHub Action `deploy.yml` workflow will build and push the package to PyPI.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vitessce"
-version = "3.0.6"
+version = "3.0.7"
 authors = [
   { name="Mark Keller", email="mark_keller@hms.harvard.edu" },
 ]


### PR DESCRIPTION
This PR bumps the package version to 3.0.7

I updated the CHANGELOG.md to include this version (though it's not very complete right now, I figured it wouldn't hurt to pick that habit back up)

I also updated the `README.md` to point to the correct file (since the package version is indicated in `pyproject.toml` not `setup.py`)