### PR TITLE
Split interval conversion logic from the rest of multivec

### DIFF
--- a/vitessce/data_utils/multivec.py
+++ b/vitessce/data_utils/multivec.py
@@ -7,14 +7,14 @@ from .anndata import to_dense
 from .entities import GenomicProfiles
 
 
-def adata_to_multivec_zarr(adata, output_path, obs_set_col, obs_set_name, obs_set_vals=None, var_interval_col="interval", layer_key=None, assembly="hg38", starting_resolution=5000):
-    in_mtx = adata.layers[layer_key] if layer_key is not None else adata.X
-    in_barcodes_df = adata.obs
-    in_bins_df = adata.var
-
-    in_mtx = to_dense(in_mtx)  # TODO: is this necessary?
-
-    # The bin datafram consists of one column like chrName:binStart-binEnd
+# Used to convert intervals to bins when the bin dataframe consists of one column like chrName:binStart-binEnd
+# Runs automatically if var_interval_col is not None in adata_to_multivec_zarr
+def convert_intervals_to_bins(in_bins_df,
+                              var_interval_col="interval",
+                              starting_resolution=5000,
+                              var_chr_name_col="chr_name",
+                              var_chr_start_col="chr_start",
+                              var_chr_end_col="chr_end"):
     def convert_bin_name_to_chr_name(bin_name):
         try:
             return bin_name[:bin_name.index(':')]
@@ -32,47 +32,82 @@ def adata_to_multivec_zarr(adata, output_path, obs_set_col, obs_set_name, obs_se
             return int(bin_name[bin_name.index('-') + 1:])
         except ValueError:
             return np.nan
-
+    var_chr_start_rounded = f"{var_chr_start_col}_round"
+    var_chr_end_rounded = f"{var_chr_end_col}_round"
     # Keep only the interval column
     in_bins_df = in_bins_df[[var_interval_col]]
-    in_bins_df = in_bins_df.rename(columns={var_interval_col: "interval"})
-    in_bins_df["chr_name"] = in_bins_df["interval"].apply(
+    in_bins_df = in_bins_df.rename(
+        columns={var_interval_col: var_interval_col})
+    in_bins_df[var_chr_name_col] = in_bins_df[var_interval_col].apply(
         convert_bin_name_to_chr_name)
-    in_bins_df["chr_start"] = in_bins_df["interval"].apply(
+    in_bins_df[var_chr_start_col] = in_bins_df[var_interval_col].apply(
         convert_bin_name_to_chr_start)
-    in_bins_df["chr_end"] = in_bins_df["interval"].apply(
+    in_bins_df[var_chr_end_col] = in_bins_df[var_interval_col].apply(
         convert_bin_name_to_chr_end)
 
     # Drop any rows that had incorrect bin strings (missing a chromosome name, bin start, or bin end value).
     in_bins_df = in_bins_df.dropna(
-        subset=["chr_name", "chr_start", "chr_end"]).copy()
+        subset=[var_chr_name_col, var_chr_start_col, var_chr_end_col]).copy()
 
     # Ensure that the columns have the expected types.
-    in_bins_df["chr_name"] = in_bins_df["chr_name"].astype(str)
-    in_bins_df["chr_start"] = in_bins_df["chr_start"].astype(int)
-    in_bins_df["chr_end"] = in_bins_df["chr_end"].astype(int)
+    in_bins_df[var_chr_name_col] = in_bins_df[var_chr_name_col].astype(str)
+    in_bins_df[var_chr_start_col] = in_bins_df[var_chr_start_col].astype(int)
+    in_bins_df[var_chr_end_col] = in_bins_df[var_chr_end_col].astype(int)
 
     in_bins_df = in_bins_df.reset_index(drop=True)
 
-    interval_sizes = in_bins_df.apply(lambda row: row["chr_end"] - row["chr_start"], axis='columns')
+    interval_sizes = in_bins_df.apply(
+        lambda row: row[var_chr_end_col] - row[var_chr_name_col], axis='columns')
     max_interval = interval_sizes.max()
     if max_interval > starting_resolution:
-        raise ValueError("Starting resolution is smaller than largest interval.")
+        raise ValueError(
+            "Starting resolution is smaller than largest interval.")
 
     # Round bins
-    in_bins_df["chr_start_round"] = in_bins_df["chr_start"].apply(lambda x: math.floor(x / starting_resolution) * starting_resolution + 1)
-    in_bins_df["chr_end_round"] = in_bins_df["chr_start_round"].apply(lambda x: x + starting_resolution - 1)
+    in_bins_df[var_chr_start_rounded] = in_bins_df[var_chr_start_col].apply(
+        lambda x: math.floor(x / starting_resolution) * starting_resolution + 1)
+    in_bins_df[var_chr_end_rounded] = in_bins_df[var_chr_start_rounded].apply(
+        lambda x: x + starting_resolution - 1)
     # TODO: do the values need to be scaled based on the ratio of the original size of the interval to the rounded size?
 
     # Replace the original start/end values
-    in_bins_df["chr_start"] = in_bins_df["chr_start_round"]
-    in_bins_df["chr_end"] = in_bins_df["chr_end_round"]
-    in_bins_df = in_bins_df.drop(columns=["chr_start_round", "chr_end_round"])
-    in_bins_df["interval"] = in_bins_df.apply(lambda r: f"{r['chr_name']}:{r['chr_start']}-{r['chr_end']}", axis='columns')
+    in_bins_df[var_chr_start_col] = in_bins_df[var_chr_start_rounded]
+    in_bins_df[var_chr_end_col] = in_bins_df[var_chr_end_rounded]
+    in_bins_df = in_bins_df.drop(
+        columns=[var_chr_start_rounded, var_chr_end_rounded])
+    in_bins_df[var_interval_col] = in_bins_df.apply(
+        lambda r: f"{r[var_chr_name_col]}:{r[var_chr_start_col]}-{r[var_chr_end_col]}", axis='columns')
+
+    return in_bins_df
+
+
+
+# Used to export genomic data for GenomicProfiles view
+def adata_to_multivec_zarr(adata, output_path, obs_set_col, obs_set_name, obs_set_vals=None, var_interval_col=None, var_chr_name_col="chr_name", var_chr_start_col="chr_start", var_chr_end_col="chr_end", layer_key=None, assembly="hg38", starting_resolution=5000):
+    in_barcodes_df = adata.obs
+    in_bins_df = adata.var
+
+    if (var_interval_col is not None):
+        if var_interval_col not in adata.var.columns:
+            raise ValueError(
+                f"var_interval_col {var_interval_col} not found in adata.var.")
+        else:
+            in_bins_df = convert_intervals_to_bins(
+                in_bins_df,
+                var_interval_col,
+                starting_resolution,
+                var_chr_name_col,
+                var_chr_start_col,
+                var_chr_end_col)
+
+    in_mtx = adata.layers[layer_key] if layer_key is not None else adata.X
+
+    in_mtx = to_dense(in_mtx)  # TODO: is this necessary?
 
     # Use provided obs_set_vals if present, since these may be ordered
     # in a particular way.
-    cluster_ids = in_barcodes_df[obs_set_col].unique().tolist() if obs_set_vals is None else obs_set_vals
+    cluster_ids = in_barcodes_df[obs_set_col].unique(
+    ).tolist() if obs_set_vals is None else obs_set_vals
 
     cluster_paths = [[obs_set_name, cluster_id] for cluster_id in cluster_ids]
 
@@ -91,7 +126,7 @@ def adata_to_multivec_zarr(adata, output_path, obs_set_col, obs_set_name, obs_se
 
         # We want to check for missing bins in each chromosome separately,
         # otherwise too much memory is used during the join step.
-        chr_bins_in_df = in_bins_df.loc[in_bins_df["chr_name"] == chr_name]
+        chr_bins_in_df = in_bins_df.loc[in_bins_df[var_chr_name_col] == chr_name]
         if chr_bins_in_df.shape[0] == 0:
             # No processing or output is necessary if there is no data for this chromosome.
             # Continue on through all resolutions of this chromosome to the next chromosome.
@@ -106,16 +141,18 @@ def adata_to_multivec_zarr(adata, output_path, obs_set_col, obs_set_name, obs_se
         # Create a list of the "ground truth" bins (all bins from position 0 to the end of the chromosome).
         # We will join the input bins onto this dataframe to determine which bins are missing.
         chr_bins_gt_df = pd.DataFrame()
-        chr_bins_gt_df["chr_start"] = np.arange(0, math.ceil(
+        chr_bins_gt_df[var_chr_start_col] = np.arange(0, math.ceil(
             chr_len / starting_resolution)) * starting_resolution
-        chr_bins_gt_df["chr_end"] = chr_bins_gt_df["chr_start"] + \
+        chr_bins_gt_df[var_chr_end_col] = chr_bins_gt_df[var_chr_start_col] + \
             starting_resolution
-        chr_bins_gt_df["chr_start"] = chr_bins_gt_df["chr_start"] + 1
-        chr_bins_gt_df["chr_start"] = chr_bins_gt_df["chr_start"].astype(
+        chr_bins_gt_df[var_chr_start_col] = chr_bins_gt_df[var_chr_start_col] + 1
+        chr_bins_gt_df[var_chr_start_col] = chr_bins_gt_df[var_chr_start_col].astype(
             int)
-        chr_bins_gt_df["chr_end"] = chr_bins_gt_df["chr_end"].astype(int)
-        chr_bins_gt_df["chr_name"] = chr_name
-        chr_bins_gt_df[0] = chr_bins_gt_df.apply(lambda r: f"{r['chr_name']}:{r['chr_start']}-{r['chr_end']}", axis='columns')
+        chr_bins_gt_df[var_chr_end_col] = chr_bins_gt_df[var_chr_end_col].astype(
+            int)
+        chr_bins_gt_df[var_chr_name_col] = chr_name
+        chr_bins_gt_df[0] = chr_bins_gt_df.apply(
+            lambda r: f"{r[var_chr_name_col]}:{r[var_chr_start_col]}-{r[var_chr_end_col]}", axis='columns')
 
         # We will add a new column "i", which should match the _old_ index, so that we will be able join with the data matrix on the original indices.
         # For the new rows, we will add values for the "i" column that are greater than any of the original indices,
@@ -139,15 +176,17 @@ def adata_to_multivec_zarr(adata, output_path, obs_set_col, obs_set_name, obs_se
 
         # Clean up the joined data frame by removing unnecessary columns.
         chr_bins_in_join_df = chr_bins_in_join_df.drop(
-            columns=['chr_name', 'chr_start', 'chr_end', 'i_gt'])
+            columns=[var_chr_name_col, var_chr_start_col, var_chr_end_col, 'i_gt'])
         chr_bins_in_join_df = chr_bins_in_join_df.rename(
-            columns={'chr_name_gt': 'chr_name', 'chr_start_gt': 'chr_start', 'chr_end_gt': 'chr_end'})
+            columns={f'{var_chr_name_col}_gt': var_chr_name_col,
+                     f'{var_chr_start_col}_gt': var_chr_start_col,
+                     f'{var_chr_end_col}_gt': var_chr_end_col})
 
         # Create a dataframe from the data matrix, so that we can join to the joined bins dataframe.
         chr_mtx_df = pd.DataFrame(data=chr_mtx.T)
 
         chr_bins_i_df = chr_bins_in_join_df.drop(
-            columns=['chr_name', 'chr_start', 'chr_end'])
+            columns=[var_chr_name_col, var_chr_start_col, var_chr_end_col])
 
         # Join the data matrix dataframe and the bins dataframe.
         # Bins that are missing from the data matrix will have "i" values higher than any of the data matrix dataframe row indices,

--- a/vitessce/data_utils/multivec.py
+++ b/vitessce/data_utils/multivec.py
@@ -36,8 +36,6 @@ def convert_intervals_to_bins(in_bins_df,
     var_chr_end_rounded = f"{var_chr_end_col}_round"
     # Keep only the interval column
     in_bins_df = in_bins_df[[var_interval_col]]
-    in_bins_df = in_bins_df.rename(
-        columns={var_interval_col: var_interval_col})
     in_bins_df[var_chr_name_col] = in_bins_df[var_interval_col].apply(
         convert_bin_name_to_chr_name)
     in_bins_df[var_chr_start_col] = in_bins_df[var_interval_col].apply(
@@ -99,7 +97,8 @@ def adata_to_multivec_zarr(adata, output_path, obs_set_col, obs_set_name, obs_se
                 var_chr_name_col,
                 var_chr_start_col,
                 var_chr_end_col)
-
+    # Ensure that in_bins_df has a sequential integer index
+    in_bins_df = in_bins_df.reset_index()
     in_mtx = adata.layers[layer_key] if layer_key is not None else adata.X
 
     in_mtx = to_dense(in_mtx)  # TODO: is this necessary?


### PR DESCRIPTION
This PR adjusts the `adata_to_multivec_zarr` helper to allow bypassing conversion to intervals, and allows the interval conversion to be run independently.

If the `var_interval_col` arg is provided, the previous conversion logic is applied; otherwise, the zarr export proceeds without converting. The chromosome name/start/end var columns are also configurable to custom values in case present values don't match the defaults.