### PR TITLE
Use anywidget-based IPC for zarr gets which do not require serving data on localhost

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   'pandas>=1.1.2',
   'black>=21.11b1',
   'numpy>=1.21.2',
-  'anndata>=0.7.8,<0.9',
+  'anndata>=0.7.8,<0.11',
   'scanpy>=1.9.3',
   'ome-zarr==0.8.3',
   'tifffile>=2020.10.1',
@@ -73,7 +73,7 @@ docs = [
 ]
 all = [
   'jupyter-server-proxy>=1.5.2',
-  'anywidget==0.4.2',
+  'anywidget>=0.9.3',
   'uvicorn>=0.17.0',
   'ujson>=4.0.1',
   'starlette==0.14.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ docs = [
 ]
 all = [
   'jupyter-server-proxy>=1.5.2',
-  'anywidget>=0.9.3',
+  'anywidget>=0.9.4',
   'uvicorn>=0.17.0',
   'ujson>=4.0.1',
   'starlette==0.14.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vitessce"
-version = "3.2.5"
+version = "3.2.6"
 authors = [
   { name="Mark Keller", email="mark_keller@hms.harvard.edu" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ docs = [
 ]
 all = [
   'jupyter-server-proxy>=1.5.2',
-  'anywidget>=0.9.4',
+  'anywidget>=0.9.10',
   'uvicorn>=0.17.0',
   'ujson>=4.0.1',
   'starlette==0.14.0',

--- a/tests/test_anndata_utils.py
+++ b/tests/test_anndata_utils.py
@@ -84,12 +84,12 @@ class TestAnnDataUtils(unittest.TestCase):
     def test_to_uint8_global_norm(self):
         adata = self.adata
         norm_X = to_uint8(adata.X, norm_along="global")
-        assert norm_X.tolist() == [[255, 200, 250], [250, 50, 255], [104, 50, 100], [200, 70, 205]]
+        np.testing.assert_almost_equal(norm_X.tolist(), [[255, 200, 250], [250, 50, 255], [104, 50, 100], [200, 70, 205]], decimal=0)
 
     def test_to_uint8_gene_norm(self):
         adata = self.adata
         norm_X = to_uint8(adata.X, norm_along="var")
-        assert norm_X.tolist() == [[255, 255, 246], [246, 0, 254], [0, 0, 0], [161, 33, 172]]
+        np.testing.assert_almost_equal(norm_X.tolist(), [[255, 255, 246], [246, 0, 254], [0, 0, 0], [161, 33, 172]], decimal=0)
 
     def test_to_uint8_cell_norm(self):
         adata = self.adata

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -226,7 +226,7 @@ class VitessceConfigDataset:
             routes += obj.get_routes()
 
         return routes
-    
+
     def get_stores(self, base_url=None):
         stores = {}
         for obj in self.objs:

--- a/vitessce/config.py
+++ b/vitessce/config.py
@@ -226,6 +226,16 @@ class VitessceConfigDataset:
             routes += obj.get_routes()
 
         return routes
+    
+    def get_stores(self, base_url=None):
+        stores = {}
+        for obj in self.objs:
+            stores = {
+                **stores,
+                **obj.get_stores(base_url)
+            }
+
+        return stores
 
 
 class VitessceConfigViewHConcat:
@@ -1488,6 +1498,21 @@ class VitessceConfig:
         for d in self.config["datasets"]:
             routes += d.get_routes()
         return routes
+
+    def get_stores(self, base_url=None):
+        """
+        Convert the routes for this view config from the datasets.
+
+        :returns: A list of server routes.
+        :rtype: list[starlette.routing.Route]
+        """
+        stores = {}
+        for d in self.config["datasets"]:
+            stores = {
+                **stores,
+                **d.get_stores(base_url)
+            }
+        return stores
 
     def to_python(self):
         """

--- a/vitessce/widget.py
+++ b/vitessce/widget.py
@@ -237,7 +237,6 @@ async function render(view) {
             }
         ])),
     );
-    console.log(stores);
 
     try {
         const pluginEsmUrl = URL.createObjectURL(new Blob([pluginEsm], { type: "text/javascript" }));
@@ -514,6 +513,7 @@ def ipython_display(config, height=600, theme='auto', base_url=None, host_name=N
         "height": height,
         "theme": theme,
         "config": config_dict,
+        "store_urls": [],
     }
 
     # We need to clean up the React and DOM state in any case in which

--- a/vitessce/widget.py
+++ b/vitessce/widget.py
@@ -149,7 +149,6 @@ def get_uid_str(uid):
 
 ESM = """
 import { importWithMap } from 'https://unpkg.com/dynamic-importmap@0.1.0';
-import * as zarr from "https://esm.sh/zarrita@next";
 const importMap = {
   imports: {
     "react": "https://esm.sh/react@18.2.0?dev",

--- a/vitessce/widget.py
+++ b/vitessce/widget.py
@@ -398,7 +398,7 @@ class VitessceWidget(anywidget.AnyWidget):
 
     next_port = DEFAULT_PORT
 
-    js_package_version = Unicode('3.3.7').tag(sync=True)
+    js_package_version = Unicode('3.3.12').tag(sync=True)
     js_dev_mode = Bool(False).tag(sync=True)
     custom_js_url = Unicode('').tag(sync=True)
     plugin_esm = Unicode(DEFAULT_PLUGIN_ESM).tag(sync=True)
@@ -406,7 +406,7 @@ class VitessceWidget(anywidget.AnyWidget):
 
     store_urls = List(trait=Unicode(''), default_value=[]).tag(sync=True)
 
-    def __init__(self, config, height=600, theme='auto', uid=None, port=None, proxy=False, js_package_version='3.3.7', js_dev_mode=False, custom_js_url='', plugin_esm=DEFAULT_PLUGIN_ESM, remount_on_uid_change=True):
+    def __init__(self, config, height=600, theme='auto', uid=None, port=None, proxy=False, js_package_version='3.3.12', js_dev_mode=False, custom_js_url='', plugin_esm=DEFAULT_PLUGIN_ESM, remount_on_uid_change=True):
         """
         Construct a new Vitessce widget.
 
@@ -492,7 +492,7 @@ class VitessceWidget(anywidget.AnyWidget):
 # Launch Vitessce using plain HTML representation (no ipywidgets)
 
 
-def ipython_display(config, height=600, theme='auto', base_url=None, host_name=None, uid=None, port=None, proxy=False, js_package_version='3.3.7', js_dev_mode=False, custom_js_url='', plugin_esm=DEFAULT_PLUGIN_ESM, remount_on_uid_change=True):
+def ipython_display(config, height=600, theme='auto', base_url=None, host_name=None, uid=None, port=None, proxy=False, js_package_version='3.3.12', js_dev_mode=False, custom_js_url='', plugin_esm=DEFAULT_PLUGIN_ESM, remount_on_uid_change=True):
     from IPython.display import display, HTML
     uid_str = "vitessce" + get_uid_str(uid)
 

--- a/vitessce/widget.py
+++ b/vitessce/widget.py
@@ -194,7 +194,7 @@ function prependBaseUrl(config, proxy, hasHostName) {
   };
 }
 
-export async function render(view) {
+async function render(view) {
     const cssUid = view.model.get('uid');
     const jsDevMode = view.model.get('js_dev_mode');
     const jsPackageVersion = view.model.get('js_package_version');
@@ -339,6 +339,7 @@ export async function render(view) {
         }
     };
 }
+export default { render };
 """
 
 DEFAULT_PLUGIN_ESM = """
@@ -382,13 +383,13 @@ class VitessceWidget(anywidget.AnyWidget):
 
     next_port = DEFAULT_PORT
 
-    js_package_version = Unicode('3.3.6').tag(sync=True)
+    js_package_version = Unicode('3.3.7').tag(sync=True)
     js_dev_mode = Bool(False).tag(sync=True)
     custom_js_url = Unicode('').tag(sync=True)
     plugin_esm = Unicode(DEFAULT_PLUGIN_ESM).tag(sync=True)
     remount_on_uid_change = Bool(True).tag(sync=True)
 
-    def __init__(self, config, height=600, theme='auto', uid=None, port=None, proxy=False, js_package_version='3.3.6', js_dev_mode=False, custom_js_url='', plugin_esm=DEFAULT_PLUGIN_ESM, remount_on_uid_change=True):
+    def __init__(self, config, height=600, theme='auto', uid=None, port=None, proxy=False, js_package_version='3.3.7', js_dev_mode=False, custom_js_url='', plugin_esm=DEFAULT_PLUGIN_ESM, remount_on_uid_change=True):
         """
         Construct a new Vitessce widget.
 
@@ -462,7 +463,7 @@ class VitessceWidget(anywidget.AnyWidget):
 # Launch Vitessce using plain HTML representation (no ipywidgets)
 
 
-def ipython_display(config, height=600, theme='auto', base_url=None, host_name=None, uid=None, port=None, proxy=False, js_package_version='3.3.6', js_dev_mode=False, custom_js_url='', plugin_esm=DEFAULT_PLUGIN_ESM, remount_on_uid_change=True):
+def ipython_display(config, height=600, theme='auto', base_url=None, host_name=None, uid=None, port=None, proxy=False, js_package_version='3.3.7', js_dev_mode=False, custom_js_url='', plugin_esm=DEFAULT_PLUGIN_ESM, remount_on_uid_change=True):
     from IPython.display import display, HTML
     uid_str = "vitessce" + get_uid_str(uid)
 

--- a/vitessce/widget.py
+++ b/vitessce/widget.py
@@ -478,7 +478,7 @@ class VitessceWidget(anywidget.AnyWidget):
     def close(self):
         self.config_obj.stop_server(self.port)
         super().close()
-    
+
     @anywidget.experimental.command
     def _zarr_get(self, params, buffers):
         [store_url, key] = params
@@ -487,7 +487,7 @@ class VitessceWidget(anywidget.AnyWidget):
             buffers = [store[key.lstrip("/")]]
         except KeyError:
             buffers = []
-        return { "success": len(buffers) == 1 }, buffers
+        return {"success": len(buffers) == 1}, buffers
 
 # Launch Vitessce using plain HTML representation (no ipywidgets)
 

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -41,8 +41,8 @@ class AbstractWrapper:
         self.out_dir = kwargs['out_dir'] if 'out_dir' in kwargs else tempfile.mkdtemp(
         )
         self.routes = []
-        self.is_remote = False # TODO: change to needs_localhost_serving for clarity
-        self.is_store = False # TODO: change to needs_store_registration for clarity
+        self.is_remote = False  # TODO: change to needs_localhost_serving for clarity
+        self.is_store = False  # TODO: change to needs_store_registration for clarity
         self.file_def_creators = []
         self.base_dir = None
         self.stores = {}
@@ -139,7 +139,7 @@ class AbstractWrapper:
                 # A store instance was passed directly, so there is no local directory path.
                 # Instead we just make one up using _get_route_str but it could be any string.
                 local_dir_path = self._get_route_str(dataset_uid, obj_i, local_dir_uid)
-            
+
             # Register the store on the same route path
             # that will be used for the "url" field in the file definition.
             if self.base_dir is None:
@@ -147,7 +147,7 @@ class AbstractWrapper:
             else:
                 route_path = file_path_to_url_path(local_dir_path)
                 local_dir_path = join(self.base_dir, local_dir_path)
-            
+
             self.stores[route_path] = store
 
     def get_local_dir_route(self, dataset_uid, obj_i, local_dir_path, local_dir_uid):
@@ -978,7 +978,6 @@ class AnnDataWrapper(AbstractWrapper):
         if num_inputs == 0:
             raise ValueError(
                 "Expected one of adata_path, adata_url, or adata_store to be provided")
-        
 
         if adata_path is not None:
             self.is_remote = False
@@ -993,7 +992,7 @@ class AnnDataWrapper(AbstractWrapper):
             self.is_remote = False
             self.is_store = True
             self.zarr_folder = None
-        
+
         self.local_dir_uid = make_unique_filename(".adata.zarr")
         self._expression_matrix = obs_feature_matrix_path
         self._cell_set_obs_names = obs_set_names

--- a/vitessce/wrappers.py
+++ b/vitessce/wrappers.py
@@ -3,7 +3,7 @@ from os.path import join
 import tempfile
 from uuid import uuid4
 from pathlib import PurePath, PurePosixPath
-from zarr.storage import DirectoryStore
+import zarr
 
 from .constants import (
     norm_enum,
@@ -41,7 +41,8 @@ class AbstractWrapper:
         self.out_dir = kwargs['out_dir'] if 'out_dir' in kwargs else tempfile.mkdtemp(
         )
         self.routes = []
-        self.is_remote = False
+        self.is_remote = False # TODO: change to needs_localhost_serving for clarity
+        self.is_store = False # TODO: change to needs_store_registration for clarity
         self.file_def_creators = []
         self.base_dir = None
         self.stores = {}
@@ -125,14 +126,28 @@ class AbstractWrapper:
             return self._get_url_simple(base_url, file_path_to_url_path(local_dir_path, prepend_slash=False))
         return self._get_url(base_url, dataset_uid, obj_i, local_dir_uid)
 
-    def register_local_dir_store(self, dataset_uid, obj_i, local_dir_path, local_dir_uid):
-        if not self.is_remote:
+    def register_zarr_store(self, dataset_uid, obj_i, store_or_local_dir_path, local_dir_uid):
+        if not self.is_remote and self.is_store:
+            # Set up `store` and `local_dir_path` variables.
+            if isinstance(store_or_local_dir_path, str):
+                # TODO: use zarr.FSStore if fsspec is installed?
+                store = zarr.DirectoryStore(store_or_local_dir_path)
+                local_dir_path = store_or_local_dir_path
+            else:
+                # TODO: check that store_or_local_dir_path is a zarr.Store or StoreLike?
+                store = store_or_local_dir_path
+                # A store instance was passed directly, so there is no local directory path.
+                # Instead we just make one up using _get_route_str but it could be any string.
+                local_dir_path = self._get_route_str(dataset_uid, obj_i, local_dir_uid)
+            
+            # Register the store on the same route path
+            # that will be used for the "url" field in the file definition.
             if self.base_dir is None:
                 route_path = self._get_route_str(dataset_uid, obj_i, local_dir_uid)
             else:
                 route_path = file_path_to_url_path(local_dir_path)
                 local_dir_path = join(self.base_dir, local_dir_path)
-            store = DirectoryStore(local_dir_path)
+            
             self.stores[route_path] = store
 
     def get_local_dir_route(self, dataset_uid, obj_i, local_dir_path, local_dir_uid):
@@ -920,12 +935,14 @@ class ObsSegmentationsOmeZarrWrapper(AbstractWrapper):
 
 
 class AnnDataWrapper(AbstractWrapper):
-    def __init__(self, adata_path=None, adata_url=None, obs_feature_matrix_path=None, feature_filter_path=None, initial_feature_filter_path=None, obs_set_paths=None, obs_set_names=None, obs_locations_path=None, obs_segmentations_path=None, obs_embedding_paths=None, obs_embedding_names=None, obs_embedding_dims=None, obs_spots_path=None, obs_points_path=None, request_init=None, feature_labels_path=None, obs_labels_path=None, convert_to_dense=True, coordination_values=None, obs_labels_paths=None, obs_labels_names=None, **kwargs):
+    def __init__(self, adata_path=None, adata_url=None, adata_store=None, obs_feature_matrix_path=None, feature_filter_path=None, initial_feature_filter_path=None, obs_set_paths=None, obs_set_names=None, obs_locations_path=None, obs_segmentations_path=None, obs_embedding_paths=None, obs_embedding_names=None, obs_embedding_dims=None, obs_spots_path=None, obs_points_path=None, request_init=None, feature_labels_path=None, obs_labels_path=None, convert_to_dense=True, coordination_values=None, obs_labels_paths=None, obs_labels_names=None, **kwargs):
         """
         Wrap an AnnData object by creating an instance of the ``AnnDataWrapper`` class.
 
         :param str adata_path: A path to an AnnData object written to a Zarr store containing single-cell experiment data.
         :param str adata_url: A remote url pointing to a zarr-backed AnnData store.
+        :param adata_store: A path to pass to zarr.FSStore, or an existing store instance.
+        :type adata_store: str or zarr.Storage
         :param str obs_feature_matrix_path: Location of the expression (cell x gene) matrix, like `X` or `obsm/highly_variable_genes_subset`
         :param str feature_filter_path: A string like `var/highly_variable` used in conjunction with `obs_feature_matrix_path` if obs_feature_matrix_path points to a subset of `X` of the full `var` list.
         :param str initial_feature_filter_path: A string like `var/highly_variable` used in conjunction with `obs_feature_matrix_path` if obs_feature_matrix_path points to a subset of `X` of the full `var` list.
@@ -952,18 +969,31 @@ class AnnDataWrapper(AbstractWrapper):
         self._repr = make_repr(locals())
         self._adata_path = adata_path
         self._adata_url = adata_url
-        if adata_url is not None and (adata_path is not None):
+        self._adata_store = adata_store
+
+        num_inputs = sum([1 for x in [adata_path, adata_url, adata_store] if x is not None])
+        if num_inputs > 1:
             raise ValueError(
-                "Did not expect adata_url to be provided with adata_path")
-        if adata_url is None and (adata_path is None):
+                "Expected only one of adata_path, adata_url, or adata_store to be provided")
+        if num_inputs == 0:
             raise ValueError(
-                "Expected either adata_url or adata_path to be provided")
+                "Expected one of adata_path, adata_url, or adata_store to be provided")
+        
+
         if adata_path is not None:
             self.is_remote = False
+            self.is_store = False
             self.zarr_folder = 'anndata.zarr'
-        else:
+        elif adata_url is not None:
             self.is_remote = True
+            self.is_store = False
             self.zarr_folder = None
+        else:
+            # Store case
+            self.is_remote = False
+            self.is_store = True
+            self.zarr_folder = None
+        
         self.local_dir_uid = make_unique_filename(".adata.zarr")
         self._expression_matrix = obs_feature_matrix_path
         self._cell_set_obs_names = obs_set_names
@@ -1004,10 +1034,11 @@ class AnnDataWrapper(AbstractWrapper):
     def make_anndata_routes(self, dataset_uid, obj_i):
         if self.is_remote:
             return []
-        else:
-            #return self.get_local_dir_route(dataset_uid, obj_i, self._adata_path, self.local_dir_uid)
-            self.register_local_dir_store(dataset_uid, obj_i, self._adata_path, self.local_dir_uid)
+        elif self.is_store:
+            self.register_zarr_store(dataset_uid, obj_i, self._adata_store, self.local_dir_uid)
             return []
+        else:
+            return self.get_local_dir_route(dataset_uid, obj_i, self._adata_path, self.local_dir_uid)
 
     def get_zarr_url(self, base_url="", dataset_uid="", obj_i=""):
         if self.is_remote:


### PR DESCRIPTION
This change enables using the Vitessce widget in HPC situations, on Google Colab, in VSCode, and in HuBMAP Workspaces with data that is local to the Python kernel. Uses the new API from https://github.com/manzt/anywidget/pull/453

In these environments it can be difficult / impossible to proxy the requests from the browser in which the notebook is running down to the server on which the python kernel is running. Jupyter-server-proxy can only get us so far. Similarly, this may also fix #255 because this is another environment that presents challenges (e.g., it is not a web browser so we cannot rely on the structure of the notebook URL to help us construct the data URLs).

TODO:
- [ ] Document this on https://vitessce.github.io/vitessce-python/data_options.html
- [ ] Register store in all Zarr-based Wrapper classes once decide how store will be passed/instantiated

One question is how to expose this in the API. Maybe we require the user to pass the store? Like

```diff
dataset = vc.add_dataset(name='Brain').add_object(AnnDataWrapper(
-       adata_path=zarr_filepath,
+       adata_store=zarr.DirectoryStore(zarr_filepath),
        obs_embedding_paths=["obsm/X_tsne"],
        obs_embedding_names=["UMAP"],
        obs_set_paths=["obs/CellType"],
        obs_set_names=["Cell Type"],
        obs_feature_matrix_path="X",
        initial_feature_filter_path="var/top_highly_variable"
    )
)
```

This would allow more than just DirectoryStores but would require more work from the user.

Or maybe we keep `adata_path` and add something like `as_store` (should it be True by default?). This would not allow any other store types but maybe that is ok?

```diff
dataset = vc.add_dataset(name='Brain').add_object(AnnDataWrapper(
        adata_path=zarr_filepath,
+       as_store=False,
        obs_embedding_paths=["obsm/X_tsne"],
        obs_embedding_names=["UMAP"],
        obs_set_paths=["obs/CellType"],
        obs_set_names=["Cell Type"],
        obs_feature_matrix_path="X",
        initial_feature_filter_path="var/top_highly_variable"
    )
)
```

cc @manzt 

 