### PR TITLE
Fix invoke bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vitessce"
-version = "3.3.3"
+version = "3.3.4"
 authors = [
   { name="Mark Keller", email="mark_keller@hms.harvard.edu" },
 ]

--- a/vitessce/widget.py
+++ b/vitessce/widget.py
@@ -242,8 +242,9 @@ async function render(view) {
     );
 
     function invokePluginCommand(commandName, commandParams, commandBuffers) {
-        return view.experimental.invoke("_plugin_command", [commandName, commandParams], commandBuffers, {
+        return view.experimental.invoke("_plugin_command", [commandName, commandParams], {
             signal: AbortSignal.timeout(invokeTimeout),
+            ...(commandBuffers ? { buffers: commandBuffers } : {}),
         });
     }
 


### PR DESCRIPTION
I was incorrect, the signature of the `invoke` function is `invoke(name, params, options = { buffers, signal })`. (For some reason I thought the third parameter was `buffers` and the fourth was `options`)

cc @EricMoerthVis 